### PR TITLE
Add API-Key export CLI example with CSV serialization and docs

### DIFF
--- a/apps/documentation/docs/examples-api-key-export.md
+++ b/apps/documentation/docs/examples-api-key-export.md
@@ -1,0 +1,62 @@
+# API-Key Datenexport Example
+
+Das Example `@budgetbuddyde/example-api-key-client` zeigt, wie Daten aus dem BudgetBuddyDE Backend mit einem persönlichen API-Key exportiert werden können. Die CLI ist in TypeScript geschrieben und verwendet den lokalen API-Client `@budgetbuddyde/api` sowie die CSV-Utility `toCSV` aus `@budgetbuddyde/utils`.
+
+## Voraussetzungen
+
+Lege einen API-Key in BudgetBuddyDE an und stelle die Backend-URL bereit:
+
+```bash
+export BUDGETBUDDY_API_KEY="bb-your-api-key"
+export BUDGETBUDDY_BACKEND_URL="https://backend.budgetbuddy.de"
+```
+
+Optional begrenzt `BUDGETBUDDY_RESULT_LIMIT` die Anzahl der Datensätze pro Entität. Ohne Wert werden bis zu `100` Datensätze exportiert.
+
+## Build
+
+```bash
+npm run build --workspace=@budgetbuddyde/api
+npm run build --workspace=@budgetbuddyde/utils
+npm run build --workspace=@budgetbuddyde/example-api-key-client
+```
+
+## Alle Daten exportieren
+
+Ohne `--entity` exportiert die CLI alle unterstützten Entitäten. Als Formate stehen `json` und `csv` zur Verfügung:
+
+```bash
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --format json
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --format csv
+```
+
+## Einzelne Entität exportieren
+
+Mit `--entity` wird nur eine Entität exportiert:
+
+```bash
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --entity transactions --format json
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --entity categories --format csv
+```
+
+Unterstützte Entitäten sind:
+
+- `transactions`
+- `recurringPayments`
+- `categories`
+- `paymentMethods`
+- `budgets`
+
+## Einzelnen Datensatz exportieren
+
+Für einen einzelnen Datensatz wird zusätzlich `--id` übergeben:
+
+```bash
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --entity categories --id <category-id> --format json
+```
+
+`--id` kann nicht mit `--entity all` kombiniert werden, weil der Datensatz eindeutig zu einer Entität gehören muss. Mit `--verbose` oder `-v` wird das Log-Level von `info` auf `debug` erhöht. Logs werden auf stderr geschrieben, damit die exportierten Daten auf stdout bleiben.
+
+## Authentifikation
+
+Die CLI sendet den API-Key bei jedem Request als HTTP-Header `x-api-key`. Zusätzlich wird `Accept: application/json` gesetzt.

--- a/apps/documentation/zensical.toml
+++ b/apps/documentation/zensical.toml
@@ -72,6 +72,9 @@ nav = [
                 "monitoring/open-telemetry.md",
             ]}
         ]},
+        {"Examples" = [
+            "examples-api-key-export.md"
+        ]},
         {"Packages" = [
             "packages/api.md",
             "packages/db.md",

--- a/examples/api-key-client/README.md
+++ b/examples/api-key-client/README.md
@@ -1,6 +1,6 @@
 # API Key Client Example
 
-Minimal Node.js TypeScript example for reading BudgetBuddyDE data with `@budgetbuddyde/api` and a user API key.
+Node.js TypeScript CLI example for exporting BudgetBuddyDE data with `@budgetbuddyde/api`, `@budgetbuddyde/utils` and a user API key.
 
 ## Environment Variables
 
@@ -8,16 +8,38 @@ Minimal Node.js TypeScript example for reading BudgetBuddyDE data with `@budgetb
 | -------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
 | `BUDGETBUDDY_API_KEY`      | Yes      | User API key created in the BudgetBuddyDE settings. The example sends it as the `x-api-key` header.         |
 | `BUDGETBUDDY_BACKEND_URL`  | Yes      | Base URL of the BudgetBuddyDE backend, for example `https://backend.budgetbuddy.de` or a local backend URL. |
-| `BUDGETBUDDY_RESULT_LIMIT` | No       | Number of transactions and recurring payments to fetch. Defaults to `5` when unset or invalid.              |
+| `BUDGETBUDDY_RESULT_LIMIT` | No       | Number of records to fetch per entity for collection exports. Defaults to `100` when unset or invalid.      |
 
 Copy `.env.example` to `.env` as a starting point, or export the variables in your shell. The example loads `.env` via `dotenv`.
 
-## Run
+## Build
 
 ```bash
-export BUDGETBUDDY_API_KEY="bb-your-api-key"
-export BUDGETBUDDY_BACKEND_URL="https://backend.budgetbuddy.de"
-
+npm run build --workspace=@budgetbuddyde/api
+npm run build --workspace=@budgetbuddyde/utils
 npm run build --workspace=@budgetbuddyde/example-api-key-client
-npm run start --workspace=@budgetbuddyde/example-api-key-client
 ```
+
+## Export all entities
+
+```bash
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --format json
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --format csv
+```
+
+## Export one entity
+
+```bash
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --entity transactions --format json
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --entity categories --format csv
+```
+
+Supported entities are `transactions`, `recurringPayments`, `categories`, `paymentMethods` and `budgets`.
+
+## Export one record
+
+```bash
+npm run start --workspace=@budgetbuddyde/example-api-key-client -- --entity categories --id <category-id> --format json
+```
+
+`--id` can only be used together with a single `--entity`. Use `--verbose` or `-v` to raise the CLI log level from `info` to `debug`. Logs are written to stderr so exported data stays on stdout.

--- a/examples/api-key-client/package.json
+++ b/examples/api-key-client/package.json
@@ -22,7 +22,10 @@
   "dependencies": {
     "@budgetbuddyde/api": "*",
     "dotenv": "^17.2.3",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "@budgetbuddyde/utils": "*",
+    "@budgetbuddyde/logger": "0.1.1",
+    "winston": "^3.19.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/examples/api-key-client/src/auth.ts
+++ b/examples/api-key-client/src/auth.ts
@@ -1,0 +1,8 @@
+export function createApiKeyRequestConfig(apiKey: string): RequestInit {
+  return {
+    headers: {
+      Accept: 'application/json',
+      'x-api-key': apiKey,
+    },
+  };
+}

--- a/examples/api-key-client/src/cli.ts
+++ b/examples/api-key-client/src/cli.ts
@@ -1,0 +1,57 @@
+import {InvalidCliArgumentError} from './errors';
+import {exportEntities, exportFormats, type ExportCommand, type ExportEntity, type ExportFormat} from './types';
+
+function isExportEntity(value: string): value is ExportEntity {
+  return exportEntities.includes(value as ExportEntity);
+}
+
+function isExportFormat(value: string): value is ExportFormat {
+  return exportFormats.includes(value as ExportFormat);
+}
+
+export function parseCliArgs(args: string[]): ExportCommand {
+  const command: ExportCommand = {entity: 'all', format: 'json', verbose: false};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const value = args[index + 1];
+
+    if (arg === '--verbose' || arg === '-v') {
+      command.verbose = true;
+      continue;
+    }
+
+    if (arg === '--entity' || arg === '-e') {
+      if (!value || (!isExportEntity(value) && value !== 'all')) {
+        throw new InvalidCliArgumentError(`--entity must be one of: all, ${exportEntities.join(', ')}`);
+      }
+      command.entity = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--format' || arg === '-f') {
+      if (!value || !isExportFormat(value)) {
+        throw new InvalidCliArgumentError(`--format must be one of: ${exportFormats.join(', ')}`);
+      }
+      command.format = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--id') {
+      if (!value) throw new InvalidCliArgumentError('--id requires a value');
+      command.id = value;
+      index += 1;
+      continue;
+    }
+
+    throw new InvalidCliArgumentError(`Unknown argument: ${arg}`);
+  }
+
+  if (command.entity === 'all' && command.id) {
+    throw new InvalidCliArgumentError('--id can only be used with a single --entity');
+  }
+
+  return command;
+}

--- a/examples/api-key-client/src/config.ts
+++ b/examples/api-key-client/src/config.ts
@@ -1,0 +1,24 @@
+import {EnvironmentVariableNotSetError} from './errors';
+import type {ExampleConfig} from './types';
+
+const DEFAULT_RESULT_LIMIT = 100;
+
+function getRequiredEnv(env: NodeJS.ProcessEnv, variableName: string) {
+  const value = env[variableName]?.trim();
+
+  if (!value) {
+    throw new EnvironmentVariableNotSetError(variableName);
+  }
+
+  return value;
+}
+
+export function readConfigFromEnv(env: NodeJS.ProcessEnv = process.env): ExampleConfig {
+  const limit = Number(env.BUDGETBUDDY_RESULT_LIMIT ?? DEFAULT_RESULT_LIMIT);
+
+  return {
+    apiKey: getRequiredEnv(env, 'BUDGETBUDDY_API_KEY'),
+    backendUrl: getRequiredEnv(env, 'BUDGETBUDDY_BACKEND_URL'),
+    limit: Number.isFinite(limit) && limit > 0 ? limit : DEFAULT_RESULT_LIMIT,
+  };
+}

--- a/examples/api-key-client/src/errors.ts
+++ b/examples/api-key-client/src/errors.ts
@@ -1,0 +1,13 @@
+export class EnvironmentVariableNotSetError extends Error {
+  constructor(variableName: string) {
+    super(`${variableName} is required`);
+    this.name = 'EnvironmentVariableNotSetError';
+  }
+}
+
+export class InvalidCliArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidCliArgumentError';
+  }
+}

--- a/examples/api-key-client/src/export.ts
+++ b/examples/api-key-client/src/export.ts
@@ -1,0 +1,93 @@
+import {Api} from '@budgetbuddyde/api';
+import type {
+  TBudget,
+  TCategory,
+  TExpandedRecurringPayment,
+  TExpandedTransaction,
+  TPaymentMethod,
+} from '@budgetbuddyde/api/types';
+import {createApiKeyRequestConfig} from './auth';
+import type {CliLogger} from './logger';
+import {
+  exportEntities,
+  type ExampleConfig,
+  type ExportableRecord,
+  type ExportCommand,
+  type ExportEntity,
+  type ExportResult,
+} from './types';
+
+function unwrapData<T>(entity: ExportEntity, response: {data?: T | T[] | null}) {
+  if (Array.isArray(response.data)) return response.data;
+  if (response.data) return [response.data];
+  throw new Error(`No data returned for ${entity}`);
+}
+
+async function unwrapResult<T extends object>(
+  entity: ExportEntity,
+  result: Promise<[{data?: T | T[] | null}, null] | [null, Error]>,
+) {
+  const [response, error] = await result;
+  if (error) throw error;
+  return unwrapData(entity, response as {data?: T | T[] | null});
+}
+
+export async function fetchExportEntity(
+  api: Api,
+  entity: ExportEntity,
+  requestConfig: RequestInit,
+  limit: number,
+  id?: string,
+): Promise<ExportableRecord[]> {
+  const query = {from: 0, to: limit};
+
+  switch (entity) {
+    case 'transactions':
+      return id
+        ? unwrapResult<TExpandedTransaction>(entity, api.backend.transaction.getById(id, requestConfig))
+        : unwrapResult<TExpandedTransaction>(entity, api.backend.transaction.getAll(query, requestConfig));
+    case 'recurringPayments':
+      return id
+        ? unwrapResult<TExpandedRecurringPayment>(entity, api.backend.recurringPayment.getById(id, requestConfig))
+        : unwrapResult<TExpandedRecurringPayment>(entity, api.backend.recurringPayment.getAll(query, requestConfig));
+    case 'categories':
+      return id
+        ? unwrapResult<TCategory>(entity, api.backend.category.getById(id, requestConfig))
+        : unwrapResult<TCategory>(entity, api.backend.category.getAll(query, requestConfig));
+    case 'paymentMethods':
+      return id
+        ? unwrapResult<TPaymentMethod>(entity, api.backend.paymentMethod.getById(id, requestConfig))
+        : unwrapResult<TPaymentMethod>(entity, api.backend.paymentMethod.getAll(query, requestConfig));
+    case 'budgets':
+      return id
+        ? unwrapResult<TBudget>(entity, api.backend.budget.getById(id, requestConfig))
+        : unwrapResult<TBudget>(entity, api.backend.budget.getAll(query, requestConfig));
+  }
+}
+
+export async function fetchBudgetBuddyExport(
+  config: ExampleConfig,
+  command: ExportCommand,
+  logger?: CliLogger,
+): Promise<ExportResult> {
+  const api = new Api(config.backendUrl);
+  const requestConfig = createApiKeyRequestConfig(config.apiKey);
+  const entities = command.entity === 'all' ? exportEntities : [command.entity];
+  const result: ExportResult = {};
+
+  logger?.info('Starting BudgetBuddyDE export', {
+    backendUrl: config.backendUrl,
+    entity: command.entity,
+    format: command.format,
+    id: command.id,
+  });
+  logger?.debug('Export pagination configured', {from: 0, to: config.limit});
+
+  for (const entity of entities) {
+    logger?.debug('Fetching entity', {entity, id: command.id});
+    result[entity] = await fetchExportEntity(api, entity, requestConfig, config.limit, command.id);
+    logger?.info('Fetched entity records', {entity, count: result[entity]?.length ?? 0});
+  }
+
+  return result;
+}

--- a/examples/api-key-client/src/index.spec.ts
+++ b/examples/api-key-client/src/index.spec.ts
@@ -3,10 +3,14 @@ import {afterEach, describe, expect, it, vi} from 'vitest';
 import {
   EnvironmentVariableNotSetError,
   createApiKeyRequestConfig,
+  createCliLogger,
   determineNextExecutionDate,
   fetchBudgetBuddyOverview,
+  fetchBudgetBuddyExport,
   formatPaymentDetails,
+  parseCliArgs,
   readConfigFromEnv,
+  serializeExport,
 } from './index';
 
 const now = '2026-06-28T12:00:00.000Z';
@@ -110,6 +114,34 @@ describe('api-key-client example', () => {
     );
   });
 
+  it('parses export CLI arguments', () => {
+    expect(parseCliArgs(['--entity', 'transactions', '--format', 'csv', '--id', 'tx_123'])).toEqual({
+      entity: 'transactions',
+      format: 'csv',
+      id: 'tx_123',
+      verbose: false,
+    });
+    expect(parseCliArgs(['--verbose'])).toEqual({entity: 'all', format: 'json', verbose: true});
+    expect(parseCliArgs([])).toEqual({entity: 'all', format: 'json', verbose: false});
+    expect(() => parseCliArgs(['--entity', 'unknown'])).toThrow('--entity must be one of');
+    expect(() => parseCliArgs(['--entity', 'all', '--id', 'tx_123'])).toThrow(
+      '--id can only be used with a single --entity',
+    );
+  });
+
+  it('configures the CLI logger with info and debug levels', () => {
+    expect(createCliLogger().level).toBe('info');
+    expect(createCliLogger(true).level).toBe('debug');
+  });
+
+  it('serializes export data as JSON and CSV', () => {
+    const exportResult = {transactions: [transactionFixture as unknown as Record<string, unknown>]};
+
+    expect(serializeExport(exportResult, 'json')).toContain('"transactions"');
+    expect(serializeExport(exportResult, 'csv')).toContain('# transactions');
+    expect(serializeExport(exportResult, 'csv')).toContain('Supermarket');
+  });
+
   it('fetches transactions and recurring payments through the API package', async () => {
     const fetchMock = vi
       .spyOn(globalThis, 'fetch')
@@ -181,5 +213,29 @@ describe('api-key-client example', () => {
     const firstRequest = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(firstRequest.headers).toBeInstanceOf(Headers);
     expect((firstRequest.headers as Headers).get('x-api-key')).toBe('bb-test-key');
+  });
+
+  it('exports a single category by id through the API package', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      jsonResponse({
+        status: 200,
+        data: category,
+      }),
+    );
+
+    const exported = await fetchBudgetBuddyExport(
+      {
+        apiKey: 'bb-test-key',
+        backendUrl: 'https://backend.example.test',
+        limit: 3,
+      },
+      {entity: 'categories', format: 'json', id: category.id, verbose: false},
+    );
+
+    expect(exported.categories).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://backend.example.test/api/category/${category.id}`,
+      expect.objectContaining({method: 'GET'}),
+    );
   });
 });

--- a/examples/api-key-client/src/index.ts
+++ b/examples/api-key-client/src/index.ts
@@ -1,147 +1,39 @@
-import {Api} from '@budgetbuddyde/api';
-import type {TExpandedRecurringPayment, TExpandedTransaction} from '@budgetbuddyde/api/types';
 import {config as loadEnv} from 'dotenv';
+import {parseCliArgs} from './cli';
+import {readConfigFromEnv} from './config';
+import {fetchBudgetBuddyExport} from './export';
+import {createCliLogger} from './logger';
+import {fetchBudgetBuddyOverview, printPayments} from './overview';
+import {serializeExport} from './serializer';
 
 loadEnv();
 
-const DEFAULT_RESULT_LIMIT = 5;
+export * from './auth';
+export * from './cli';
+export * from './config';
+export * from './errors';
+export * from './export';
+export * from './logger';
+export * from './overview';
+export * from './serializer';
+export * from './types';
 
-type ExampleConfig = {
-  apiKey: string;
-  backendUrl: string;
-  limit: number;
-};
+export async function main(args = process.argv.slice(2)) {
+  const command = parseCliArgs(args);
+  const logger = createCliLogger(command.verbose);
+  const config = readConfigFromEnv();
 
-export class EnvironmentVariableNotSetError extends Error {
-  constructor(variableName: string) {
-    super(`${variableName} is required`);
-    this.name = 'EnvironmentVariableNotSetError';
-  }
-}
-
-function getRequiredEnv(env: NodeJS.ProcessEnv, variableName: string) {
-  const value = env[variableName]?.trim();
-
-  if (!value) {
-    throw new EnvironmentVariableNotSetError(variableName);
-  }
-
-  return value;
-}
-
-function formatDate(value: Date | string) {
-  const date = value instanceof Date ? value : new Date(value);
-  return date.toISOString().slice(0, 10);
-}
-
-export function determineNextExecutionDate(executeAt: number, referenceDate = new Date()) {
-  const currentMonthExecutionDate = new Date(
-    Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth(), executeAt),
-  );
-
-  if (referenceDate.getUTCDate() < executeAt) {
-    return currentMonthExecutionDate;
-  }
-
-  return new Date(Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth() + 1, executeAt));
-}
-
-export function formatPaymentDetails(
-  payment: TExpandedTransaction | TExpandedRecurringPayment,
-  referenceDate = new Date(),
-) {
-  const details: string[] = [];
-
-  if ('processedAt' in payment) {
-    details.push(`date ${formatDate(payment.processedAt)}`);
-  }
-
-  if ('executeAt' in payment) {
-    details.push(`execution day ${payment.executeAt}`);
-
-    if (payment.paused) {
-      details.push('paused');
-    } else {
-      details.push(`next execution ${formatDate(determineNextExecutionDate(payment.executeAt, referenceDate))}`);
-    }
-  }
-
-  if (payment.information) {
-    details.push(`note ${payment.information}`);
-  }
-
-  return details.join('; ');
-}
-
-export function readConfigFromEnv(env: NodeJS.ProcessEnv = process.env): ExampleConfig {
-  const limit = Number(env.BUDGETBUDDY_RESULT_LIMIT ?? DEFAULT_RESULT_LIMIT);
-
-  return {
-    apiKey: getRequiredEnv(env, 'BUDGETBUDDY_API_KEY'),
-    backendUrl: getRequiredEnv(env, 'BUDGETBUDDY_BACKEND_URL'),
-    limit: Number.isFinite(limit) && limit > 0 ? limit : DEFAULT_RESULT_LIMIT,
-  };
-}
-
-export function createApiKeyRequestConfig(apiKey: string): RequestInit {
-  return {
-    headers: {
-      Accept: 'application/json',
-      'x-api-key': apiKey,
-    },
-  };
-}
-
-export async function fetchBudgetBuddyOverview(config: ExampleConfig) {
-  const api = new Api(config.backendUrl);
-  const requestConfig = createApiKeyRequestConfig(config.apiKey);
-  const query = {
-    from: 0,
-    to: config.limit,
-  };
-
-  const [transactions, transactionError] = await api.backend.transaction.getAll(query, requestConfig);
-  if (transactionError) {
-    throw transactionError;
-  }
-
-  const [recurringPayments, recurringPaymentError] = await api.backend.recurringPayment.getAll(query, requestConfig);
-  if (recurringPaymentError) {
-    throw recurringPaymentError;
-  }
-
-  return {
-    recurringPayments: recurringPayments.data ?? [],
-    transactions: transactions.data ?? [],
-  };
-}
-
-function printPayments(title: string, payments: Array<TExpandedTransaction | TExpandedRecurringPayment>) {
-  console.log(`\n${title}`);
-
-  if (payments.length === 0) {
-    console.log('No entries found.');
+  if (args.length === 0) {
+    const overview = await fetchBudgetBuddyOverview(config, logger);
+    console.log(`BudgetBuddyDE API example using ${config.backendUrl}`);
+    printPayments('Transactions', overview.transactions);
+    printPayments('Recurring payments', overview.recurringPayments);
     return;
   }
 
-  for (const payment of payments) {
-    const category = payment.category?.name ?? 'No category';
-    const paymentMethod = payment.paymentMethod?.name ?? 'No payment method';
-    const details = formatPaymentDetails(payment);
-    const detailsSuffix = details ? ` - ${details}` : '';
-    console.log(
-      `- ${payment.receiver}: ${payment.transferAmount.toFixed(2)} EUR (${category}, ${paymentMethod})${detailsSuffix}`,
-    );
-  }
-}
-
-export async function main() {
-  const config = readConfigFromEnv();
-  const overview = await fetchBudgetBuddyOverview(config);
-
-  console.log(`BudgetBuddyDE API example using ${config.backendUrl}`);
-  printPayments('Transactions', overview.transactions);
-  printPayments('Recurring payments', overview.recurringPayments);
+  const result = await fetchBudgetBuddyExport(config, command, logger);
+  logger.info('Serializing export result', {format: command.format});
+  process.stdout.write(serializeExport(result, command.format));
 }
 
 if (require.main === module) {

--- a/examples/api-key-client/src/logger.ts
+++ b/examples/api-key-client/src/logger.ts
@@ -1,0 +1,21 @@
+import {buildConsoleFormat, LevelConfig} from '@budgetbuddyde/logger';
+import {createLogger, format, transports, type Logger} from 'winston';
+
+const stderrLevels = Object.keys(LevelConfig.levels);
+
+export type CliLogger = Pick<Logger, 'debug' | 'info'>;
+
+export function createCliLogger(verbose = false): Logger {
+  return createLogger({
+    levels: LevelConfig.levels,
+    level: verbose ? 'debug' : 'info',
+    defaultMeta: {service: '@budgetbuddyde/example-api-key-client'},
+    format: format.combine(
+      format.timestamp({format: 'YYYY-MM-DD HH:mm:ss'}),
+      format.splat(),
+      format.colorize({level: true, colors: LevelConfig.colors}),
+      buildConsoleFormat('api-key-export', true),
+    ),
+    transports: [new transports.Console({stderrLevels})],
+  });
+}

--- a/examples/api-key-client/src/overview.ts
+++ b/examples/api-key-client/src/overview.ts
@@ -1,0 +1,89 @@
+import {Api} from '@budgetbuddyde/api';
+import type {TExpandedRecurringPayment, TExpandedTransaction} from '@budgetbuddyde/api/types';
+import {createApiKeyRequestConfig} from './auth';
+import {fetchExportEntity} from './export';
+import type {CliLogger} from './logger';
+import type {ExampleConfig} from './types';
+
+function formatDate(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toISOString().slice(0, 10);
+}
+
+export function determineNextExecutionDate(executeAt: number, referenceDate = new Date()) {
+  const currentMonthExecutionDate = new Date(
+    Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth(), executeAt),
+  );
+
+  if (referenceDate.getUTCDate() < executeAt) {
+    return currentMonthExecutionDate;
+  }
+
+  return new Date(Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth() + 1, executeAt));
+}
+
+export function formatPaymentDetails(
+  payment: TExpandedTransaction | TExpandedRecurringPayment,
+  referenceDate = new Date(),
+) {
+  const details: string[] = [];
+
+  if ('processedAt' in payment) {
+    details.push(`date ${formatDate(payment.processedAt)}`);
+  }
+
+  if ('executeAt' in payment) {
+    details.push(`execution day ${payment.executeAt}`);
+
+    if (payment.paused) {
+      details.push('paused');
+    } else {
+      details.push(`next execution ${formatDate(determineNextExecutionDate(payment.executeAt, referenceDate))}`);
+    }
+  }
+
+  if (payment.information) {
+    details.push(`note ${payment.information}`);
+  }
+
+  return details.join('; ');
+}
+
+export async function fetchBudgetBuddyOverview(config: ExampleConfig, logger?: CliLogger) {
+  const api = new Api(config.backendUrl);
+  const requestConfig = createApiKeyRequestConfig(config.apiKey);
+
+  logger?.info('Fetching BudgetBuddyDE overview', {backendUrl: config.backendUrl, limit: config.limit});
+
+  const transactions = await fetchExportEntity(api, 'transactions', requestConfig, config.limit);
+  const recurringPayments = await fetchExportEntity(api, 'recurringPayments', requestConfig, config.limit);
+
+  logger?.debug('Fetched overview data', {
+    transactions: transactions.length,
+    recurringPayments: recurringPayments.length,
+  });
+
+  return {
+    recurringPayments: recurringPayments as TExpandedRecurringPayment[],
+    transactions: transactions as TExpandedTransaction[],
+  };
+}
+
+export function printPayments(title: string, payments: Array<TExpandedTransaction | TExpandedRecurringPayment>) {
+  console.log(`\n${title}`);
+
+  if (payments.length === 0) {
+    console.log('No entries found.');
+    return;
+  }
+
+  for (const payment of payments) {
+    const category = payment.category?.name ?? 'No category';
+    const paymentMethod = payment.paymentMethod?.name ?? 'No payment method';
+    const details = formatPaymentDetails(payment);
+    const detailsSuffix = details ? ` - ${details}` : '';
+    console.log(
+      `- ${payment.receiver}: ${payment.transferAmount.toFixed(2)} EUR (${category}, ${paymentMethod})${detailsSuffix}`,
+    );
+  }
+}

--- a/examples/api-key-client/src/serializer.ts
+++ b/examples/api-key-client/src/serializer.ts
@@ -1,0 +1,32 @@
+import {toCSV, type FieldsWithAlias} from '@budgetbuddyde/utils';
+import type {ExportableRecord, ExportFormat, ExportResult} from './types';
+
+function normalizeValue(value: unknown): string | number | boolean | null {
+  if (value instanceof Date) return value.toISOString();
+  if (value === undefined) return null;
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeRecord<T extends object>(record: T): ExportableRecord {
+  return Object.fromEntries(Object.entries(record).map(([key, value]) => [key, normalizeValue(value)]));
+}
+
+function recordsToCSV(records: ExportableRecord[]) {
+  if (records.length === 0) return '';
+  const fields = Object.keys(records[0] ?? {}).map(field => ({
+    field,
+    transform: (value: ExportableRecord[keyof ExportableRecord]) => normalizeValue(value),
+  })) as FieldsWithAlias<ExportableRecord>;
+  return toCSV(records.map(normalizeRecord), fields);
+}
+
+export function serializeExport(result: ExportResult, format: ExportFormat) {
+  if (format === 'json') return `${JSON.stringify(result, null, 2)}\n`;
+
+  return Object.entries(result)
+    .map(([entity, records]) => [`# ${entity}`, recordsToCSV(records ?? [])].filter(Boolean).join('\n'))
+    .join('\n\n');
+}

--- a/examples/api-key-client/src/types.ts
+++ b/examples/api-key-client/src/types.ts
@@ -1,0 +1,21 @@
+export const exportEntities = ['transactions', 'recurringPayments', 'categories', 'paymentMethods', 'budgets'] as const;
+export const exportFormats = ['json', 'csv'] as const;
+
+export type ExportEntity = (typeof exportEntities)[number];
+export type ExportFormat = (typeof exportFormats)[number];
+export type ExportableRecord = Record<string, unknown>;
+
+export type ExampleConfig = {
+  apiKey: string;
+  backendUrl: string;
+  limit: number;
+};
+
+export type ExportCommand = {
+  entity: ExportEntity | 'all';
+  format: ExportFormat;
+  id?: string;
+  verbose: boolean;
+};
+
+export type ExportResult = Partial<Record<ExportEntity, ExportableRecord[]>>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@budgetbuddyde/api": "*",
+        "@budgetbuddyde/logger": "0.1.1",
+        "@budgetbuddyde/utils": "*",
         "dotenv": "^17.2.3",
+        "winston": "^3.19.0",
         "zod": "^4.1.12"
       },
       "devDependencies": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './getCurrentRuntime';
 export * from './getPort';
 export * from './getTrustedOrigins';
 export * from './isRunningInProd';
+export * from './toCSV';


### PR DESCRIPTION
### Motivation

- Provide a TypeScript CLI example that demonstrates exporting BudgetBuddyDE data using a personal API key and the local `@budgetbuddyde/api` client.  
- Offer JSON and CSV export formats and surface a simple, reusable serializer using existing utilities.  

### Description

- Add a new example package `@budgetbuddyde/example-api-key-client` with modularized source files: `auth.ts`, `cli.ts`, `config.ts`, `errors.ts`, `export.ts`, `overview.ts`, `logger.ts`, `serializer.ts`, and `types.ts`.  
- Update `examples/api-key-client/README.md` with build/run instructions and export examples, and add a new documentation page `apps/documentation/docs/examples-api-key-export.md` plus a navigation entry in `apps/documentation/zensical.toml`.  
- Extend example package `package.json` dependencies to include `@budgetbuddyde/utils`, `@budgetbuddyde/logger`, and `winston`, and update `package-lock.json` accordingly.  
- Export `toCSV` from `packages/utils` by adding `export * from './toCSV';` to `packages/utils/src/index.ts` so the example can produce CSV output.  
- Add unit tests and update `src/index.spec.ts` to cover CLI parsing, logger creation, serialization, and API export flows.  

### Testing

- Ran the example package unit tests via `vitest` (`npm run test --workspace=@budgetbuddyde/example-api-key-client`) and the test suite passed.  
- Built the example with `npm run build --workspace=@budgetbuddyde/example-api-key-client` to ensure TypeScript compiles successfully and the serializer integrates with `@budgetbuddyde/utils`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd04e3db88322a1a356ed192dadc9)