### PR TITLE
Add quick filters for Transactions and Recurring Payments

### DIFF
--- a/apps/webapp/src/components/Filter/FilterDialog.tsx
+++ b/apps/webapp/src/components/Filter/FilterDialog.tsx
@@ -11,6 +11,8 @@ import {
   DialogTitle,
   Stack,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
   useMediaQuery,
   useTheme,
@@ -27,6 +29,7 @@ export type FilterDialogProps = Pick<DialogProps, 'open'> & {
   onReset?: () => void;
   onApply?: () => void;
   withDateRange?: boolean;
+  withRecurringPaymentStatus?: boolean;
   withExecuteDay?: boolean;
   withCategories?: boolean;
   withPaymentMethods?: boolean;
@@ -48,6 +51,7 @@ export const FilterDialog: React.FC<FilterDialogProps> = ({
   onReset,
   onApply,
   withDateRange,
+  withRecurringPaymentStatus,
   withExecuteDay,
   withCategories,
   withPaymentMethods,
@@ -110,6 +114,25 @@ export const FilterDialog: React.FC<FilterDialogProps> = ({
                   },
                 }}
               />
+            </Stack>
+          )}
+
+          {withRecurringPaymentStatus && (
+            <Stack gap={1}>
+              <SectionLabel label="Status" />
+              <ToggleButtonGroup
+                size="small"
+                exclusive
+                value={state.paused === null ? null : state.paused ? 'inactive' : 'active'}
+                onChange={(_, value) => {
+                  if (!value) return;
+                  dispatch({action: 'SET_PAUSED', paused: value === 'inactive'});
+                }}
+                aria-label="Recurring payment status quick filters"
+              >
+                <ToggleButton value="active">Active</ToggleButton>
+                <ToggleButton value="inactive">Inactive</ToggleButton>
+              </ToggleButtonGroup>
             </Stack>
           )}
 

--- a/apps/webapp/src/components/Filter/FilterReducer.ts
+++ b/apps/webapp/src/components/Filter/FilterReducer.ts
@@ -6,6 +6,7 @@ export type Filters<C = TCategoryVH, P = TPaymentMethodVH> = {
   hasActiveFilters: boolean;
   keywords: string | null;
   dateRange: DateRangeState;
+  paused: boolean | null;
   executeFrom: string;
   executeTo: string;
   categories: C[];
@@ -19,6 +20,7 @@ export function getInitialFilterState(): FilterState {
     hasActiveFilters: false,
     keywords: null,
     dateRange: {startDate: null, endDate: null},
+    paused: null,
     executeFrom: '',
     executeTo: '',
     categories: [],
@@ -31,6 +33,7 @@ export type FilterAction =
   | {action: 'SET_DATE_RANGE'; startDate: Date | null; endDate: Date | null}
   | {action: 'SET_START_DATE'; startDate: Date | null}
   | {action: 'SET_END_DATE'; endDate: Date | null}
+  | {action: 'SET_PAUSED'; paused: boolean | null}
   | {action: 'SET_EXECUTE_FROM'; executeFrom: string}
   | {action: 'SET_EXECUTE_TO'; executeTo: string}
   | {action: 'SET_CATEGORIES'; categories: TCategoryVH[]}
@@ -61,6 +64,9 @@ export function FilterReducer(state: FilterState, action: FilterAction): FilterS
         dateRange: {startDate: state.dateRange.startDate ?? null, endDate: action.endDate},
       };
       return {...updatedState, hasActiveFilters: determineHasActiveFilters(updatedState)};
+    case 'SET_PAUSED':
+      updatedState = {...state, paused: action.paused};
+      return {...updatedState, hasActiveFilters: determineHasActiveFilters(updatedState)};
     case 'SET_EXECUTE_FROM':
       updatedState = {...state, executeFrom: action.executeFrom};
       return {...updatedState, hasActiveFilters: determineHasActiveFilters(updatedState)};
@@ -85,6 +91,7 @@ function determineHasActiveFilters(state: FilterState): boolean {
     state.keywords ||
     state.dateRange.startDate ||
     state.dateRange.endDate ||
+    state.paused !== null ||
     state.executeFrom ||
     state.executeTo ||
     state.categories.length > 0 ||

--- a/apps/webapp/src/components/Filter/QuickFilterAutocomplete.test.tsx
+++ b/apps/webapp/src/components/Filter/QuickFilterAutocomplete.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+import {describe, expect, it, vi} from 'vitest';
+import {QuickFilterAutocomplete} from './QuickFilterAutocomplete';
+
+describe('QuickFilterAutocomplete', () => {
+  it('filters its compact option list without rendering checkboxes', () => {
+    render(
+      <QuickFilterAutocomplete
+        label="Category"
+        value={[]}
+        options={[
+          {id: 'food', label: 'Food'},
+          {id: 'rent', label: 'Rent'},
+        ]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole('combobox', {name: 'Category'});
+    fireEvent.focus(input);
+    fireEvent.change(input, {target: {value: 'foo'}});
+
+    expect(screen.getByRole('option', {name: 'Food'})).toBeTruthy();
+    expect(screen.queryByRole('option', {name: 'Rent'})).toBeNull();
+    expect(document.querySelector('input[type="checkbox"]')).toBeNull();
+  });
+});

--- a/apps/webapp/src/components/Filter/QuickFilterAutocomplete.tsx
+++ b/apps/webapp/src/components/Filter/QuickFilterAutocomplete.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import {Autocomplete, CircularProgress, TextField, Typography} from '@mui/material';
+import React from 'react';
+
+export type QuickFilterAutocompleteOption = {
+  id: string;
+  label: string;
+};
+
+export type QuickFilterAutocompleteProps = {
+  label: string;
+  value: string[];
+  options: QuickFilterAutocompleteOption[];
+  loading?: boolean;
+  width?: number;
+  onChange: (value: string[]) => void;
+};
+
+export const QuickFilterAutocomplete: React.FC<QuickFilterAutocompleteProps> = ({
+  label,
+  value,
+  options,
+  loading = false,
+  width = 184,
+  onChange,
+}) => {
+  const selectedOptions = options.filter(option => value.includes(option.id));
+
+  return (
+    <Autocomplete<QuickFilterAutocompleteOption, true>
+      multiple
+      disableCloseOnSelect
+      autoHighlight
+      selectOnFocus
+      size="small"
+      value={selectedOptions}
+      options={options}
+      loading={loading}
+      onChange={(_, selected) => onChange(selected.map(option => option.id))}
+      getOptionLabel={option => option.label}
+      isOptionEqualToValue={(option, selected) => option.id === selected.id}
+      renderTags={selected => {
+        const selectedLabel = selected.length === 1 ? selected[0].label : `${selected.length} selected`;
+        return (
+          <Typography component="span" variant="body2" noWrap sx={{maxWidth: Math.max(72, width - 112), flexShrink: 1}}>
+            {selectedLabel}
+          </Typography>
+        );
+      }}
+      renderOption={(props, option) => (
+        <li {...props} key={option.id}>
+          {option.label}
+        </li>
+      )}
+      renderInput={params => (
+        <TextField
+          {...params}
+          placeholder={selectedOptions.length === 0 ? label : undefined}
+          slotProps={{
+            htmlInput: {
+              ...params.inputProps,
+              'aria-label': label,
+            },
+            input: {
+              ...params.InputProps,
+              endAdornment: (
+                <React.Fragment>
+                  {loading ? <CircularProgress color="inherit" size={18} /> : null}
+                  {params.InputProps.endAdornment}
+                </React.Fragment>
+              ),
+            },
+          }}
+        />
+      )}
+      noOptionsText={`No ${label.toLowerCase()} found`}
+      slotProps={{
+        paper: {elevation: 0, sx: {mt: 0.5}},
+        listbox: {
+          sx: {
+            p: 0.5,
+            '& .MuiAutocomplete-option': {
+              minHeight: 32,
+              px: 1,
+              py: 0.5,
+              fontSize: '0.875rem',
+            },
+          },
+        },
+      }}
+      sx={{
+        width,
+        minWidth: 0,
+        '& .MuiAutocomplete-input': {
+          minWidth: '36px !important',
+        },
+      }}
+    />
+  );
+};

--- a/apps/webapp/src/components/Filter/QuickFilterSelect.test.tsx
+++ b/apps/webapp/src/components/Filter/QuickFilterSelect.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+import {describe, expect, it, vi} from 'vitest';
+import {QuickFilterSelect} from './QuickFilterSelect';
+
+describe('QuickFilterSelect', () => {
+  it('renders its options and applies the selected quick filter', () => {
+    const onChange = vi.fn();
+    render(
+      <QuickFilterSelect
+        label="Time period"
+        resetLabel="All dates"
+        value=""
+        options={[
+          {value: 'today', label: 'Today'},
+          {value: 'thisWeek', label: 'This Week'},
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    const select = screen.getByRole('combobox', {name: 'Time period'});
+    fireEvent.mouseDown(select);
+    fireEvent.click(screen.getByRole('option', {name: 'Today'}));
+
+    expect(onChange).toHaveBeenCalledWith('today');
+  });
+});

--- a/apps/webapp/src/components/Filter/QuickFilterSelect.tsx
+++ b/apps/webapp/src/components/Filter/QuickFilterSelect.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import {FormControl, MenuItem, OutlinedInput, Select, type SelectChangeEvent} from '@mui/material';
+import React from 'react';
+
+export type QuickFilterSelectOption = {
+  value: string;
+  label: string;
+};
+
+export type QuickFilterSelectProps = {
+  label: string;
+  resetLabel: string;
+  value: string;
+  options: QuickFilterSelectOption[];
+  width?: number;
+  onChange: (value: string) => void;
+};
+
+export const QuickFilterSelect: React.FC<QuickFilterSelectProps> = ({
+  label,
+  resetLabel,
+  value,
+  options,
+  width = 160,
+  onChange,
+}) => {
+  const handleChange = (event: SelectChangeEvent) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <FormControl size="small" sx={{width, minWidth: 0}}>
+      <Select
+        displayEmpty
+        value={value}
+        onChange={handleChange}
+        input={<OutlinedInput />}
+        inputProps={{'aria-label': label}}
+        renderValue={selected => options.find(option => option.value === selected)?.label ?? label}
+        MenuProps={{
+          slotProps: {
+            paper: {
+              elevation: 0,
+              sx: {
+                mt: 0.5,
+                '& .MuiList-root': {
+                  m: 0.5,
+                },
+                '& .MuiMenuItem-root': {
+                  minHeight: 32,
+                  px: 1,
+                  py: 0.5,
+                  fontSize: '0.875rem',
+                },
+              },
+            },
+          },
+        }}
+        sx={{
+          height: 40,
+          color: value ? 'text.primary' : 'text.secondary',
+        }}
+      >
+        <MenuItem value="">{resetLabel}</MenuItem>
+        {options.map(option => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};

--- a/apps/webapp/src/components/Filter/URLUtil/URLUtil.spec.ts
+++ b/apps/webapp/src/components/Filter/URLUtil/URLUtil.spec.ts
@@ -115,6 +115,11 @@ suite('Filter - URL utils', () => {
       expect(parseRecurringPaymentFiltersFromParams({q: 'netflix'})).toEqual({keyword: 'netflix'});
     });
 
+    it('parses paused state as boolean', () => {
+      expect(parseRecurringPaymentFiltersFromParams({paused: 'true'})).toEqual({paused: true});
+      expect(parseRecurringPaymentFiltersFromParams({paused: 'false'})).toEqual({paused: false});
+    });
+
     it('parses executeFrom as integer', () => {
       expect(parseRecurringPaymentFiltersFromParams({execFrom: '5'})).toEqual({executeFrom: 5});
     });
@@ -244,6 +249,11 @@ suite('Filter - URL utils', () => {
     it('serializes keyword', () => {
       const p = serializeRecurringPaymentFilters({...emptyFilters, keyword: 'spotify'});
       expect(p.get('q')).toBe('spotify');
+    });
+
+    it('serializes paused state as boolean string', () => {
+      const p = serializeRecurringPaymentFilters({...emptyFilters, paused: false});
+      expect(p.get('paused')).toBe('false');
     });
 
     it('serializes executeFrom as string number', () => {

--- a/apps/webapp/src/components/Filter/URLUtil/URLUtil.ts
+++ b/apps/webapp/src/components/Filter/URLUtil/URLUtil.ts
@@ -12,6 +12,7 @@ const PARAM = {
   excl_categories: 'excl_cat',
   paymentMethods: 'pm',
   excl_paymentMethods: 'excl_pm',
+  paused: 'paused',
   executeFrom: 'execFrom',
   executeTo: 'execTo',
 } as const;
@@ -77,6 +78,9 @@ export function parseRecurringPaymentFiltersFromParams(
   const q = params[PARAM.keyword];
   if (typeof q === 'string' && q) filters.keyword = q;
 
+  const paused = params[PARAM.paused];
+  if (typeof paused === 'string' && paused) filters.paused = paused === 'true';
+
   const execFrom = params[PARAM.executeFrom];
   if (typeof execFrom === 'string' && execFrom) {
     const n = parseInt(execFrom, 10);
@@ -140,6 +144,7 @@ export function serializeTransactionFilters(filters: EntityFilters): URLSearchPa
 export function serializeRecurringPaymentFilters(filters: EntityFilters): URLSearchParams {
   const p = new URLSearchParams();
   if (filters.keyword) p.set(PARAM.keyword, filters.keyword);
+  if (filters.paused != null) p.set(PARAM.paused, String(filters.paused));
   if (filters.executeFrom != null) p.set(PARAM.executeFrom, String(filters.executeFrom));
   if (filters.executeTo != null) p.set(PARAM.executeTo, String(filters.executeTo));
   if (filters.categories?.length) p.set(PARAM.categories, filters.categories.join(','));

--- a/apps/webapp/src/components/Filter/Wrapper.tsx
+++ b/apps/webapp/src/components/Filter/Wrapper.tsx
@@ -2,6 +2,7 @@
 
 import type {TCategoryVH} from '@budgetbuddyde/api/category';
 import type {TPaymentMethodVH} from '@budgetbuddyde/api/paymentMethod';
+import {Stack} from '@mui/material';
 import React from 'react';
 import {apiClient} from '@/apiClient';
 import type {EntityFilters} from '@/lib/features/createEntitySlice';
@@ -9,6 +10,18 @@ import {logger} from '@/logger';
 import {FilterButton} from './FilterButton';
 import {FilterDialog, type FilterDialogProps} from './FilterDialog';
 import {FilterReducer, getInitialFilterState} from './FilterReducer';
+import {QuickFilterAutocomplete} from './QuickFilterAutocomplete';
+import {
+  getRecurringPaymentExecutionQuickFilter,
+  getRecurringPaymentStatusQuickFilter,
+  getTransactionDateQuickFilterRange,
+  isRecurringPaymentExecutionQuickFilterActive,
+  isTransactionDateQuickFilterActive,
+  type RecurringPaymentExecutionQuickFilter,
+  type RecurringPaymentStatusQuickFilter,
+  type TransactionDateQuickFilter,
+} from './quickFilters';
+import {QuickFilterSelect} from './QuickFilterSelect';
 
 function clampDay(val: string): number | null {
   const n = parseInt(val, 10);
@@ -16,27 +29,53 @@ function clampDay(val: string): number | null {
   return Math.min(31, Math.max(1, n));
 }
 
+const transactionDateQuickFilterLabels: Record<TransactionDateQuickFilter, string> = {
+  today: 'Today',
+  thisWeek: 'This Week',
+  thisMonth: 'This Month',
+  lastMonth: 'Last Month',
+};
+
+const recurringPaymentStatusQuickFilterLabels: Record<RecurringPaymentStatusQuickFilter, string> = {
+  active: 'Active',
+  inactive: 'Inactive',
+};
+
+const recurringPaymentExecutionQuickFilterLabels: Record<RecurringPaymentExecutionQuickFilter, string> = {
+  executed: 'Executed',
+  scheduled: 'Planned',
+};
+
 export type FilterWrapperProps = Pick<
   FilterDialogProps,
-  'withCategories' | 'withExecuteDay' | 'withPaymentMethods' | 'withDateRange'
+  'withCategories' | 'withRecurringPaymentStatus' | 'withExecuteDay' | 'withPaymentMethods' | 'withDateRange'
 > & {
   currentFilters: Partial<EntityFilters>;
   onApply: (filters: Partial<EntityFilters>) => void;
+  transactionDateQuickFilters?: TransactionDateQuickFilter[];
+  recurringPaymentStatusQuickFilters?: RecurringPaymentStatusQuickFilter[];
+  recurringPaymentExecutionQuickFilters?: RecurringPaymentExecutionQuickFilter[];
 };
 
 export const FilterWrapper: React.FC<FilterWrapperProps> = ({
   currentFilters,
   onApply,
+  withRecurringPaymentStatus,
   withExecuteDay,
   withCategories,
   withPaymentMethods,
   withDateRange,
+  transactionDateQuickFilters = [],
+  recurringPaymentStatusQuickFilters = [],
+  recurringPaymentExecutionQuickFilters = [],
 }) => {
   const [open, setOpen] = React.useState(false);
   const [dialogKey, setDialogKey] = React.useState(0);
   const [state, dispatch] = React.useReducer(FilterReducer, getInitialFilterState());
   const [categoryOptions, setCategoryOptions] = React.useState<TCategoryVH[]>([]);
   const [paymentMethodOptions, setPaymentMethodOptions] = React.useState<TPaymentMethodVH[]>([]);
+  const [categoryOptionsLoading, setCategoryOptionsLoading] = React.useState(false);
+  const [paymentMethodOptionsLoading, setPaymentMethodOptionsLoading] = React.useState(false);
 
   const handleOpen = () => {
     // Bump key so FilterDialog remounts fresh (DateRangePicker re-reads defaultValue)
@@ -47,6 +86,7 @@ export const FilterWrapper: React.FC<FilterWrapperProps> = ({
       startDate: currentFilters.dateFrom ?? null,
       endDate: currentFilters.dateTo ?? null,
     });
+    dispatch({action: 'SET_PAUSED', paused: currentFilters.paused ?? null});
     dispatch({
       action: 'SET_EXECUTE_FROM',
       executeFrom: currentFilters.executeFrom != null ? String(currentFilters.executeFrom) : '',
@@ -59,34 +99,65 @@ export const FilterWrapper: React.FC<FilterWrapperProps> = ({
   };
 
   React.useEffect(() => {
+    if (!withCategories) return;
+
+    let ignoreResult = false;
+    setCategoryOptionsLoading(true);
+    void apiClient.backend.category.getValueHelp().then(([categories, error]) => {
+      if (ignoreResult) return;
+      setCategoryOptionsLoading(false);
+      if (error) logger.error('Failed to fetch category options:', error);
+      else setCategoryOptions(categories ?? []);
+    });
+
+    return () => {
+      ignoreResult = true;
+    };
+  }, [withCategories]);
+
+  React.useEffect(() => {
+    if (!withPaymentMethods) return;
+
+    let ignoreResult = false;
+    setPaymentMethodOptionsLoading(true);
+    void apiClient.backend.paymentMethod.getValueHelp().then(([paymentMethods, error]) => {
+      if (ignoreResult) return;
+      setPaymentMethodOptionsLoading(false);
+      if (error) logger.error('Failed to fetch payment method options:', error);
+      else setPaymentMethodOptions(paymentMethods ?? []);
+    });
+
+    return () => {
+      ignoreResult = true;
+    };
+  }, [withPaymentMethods]);
+
+  React.useEffect(() => {
     if (!open) return;
-    Promise.all([apiClient.backend.category.getValueHelp(), apiClient.backend.paymentMethod.getValueHelp()]).then(
-      ([[cats, catErr], [pms, pmErr]]) => {
-        if (catErr) logger.error('Failed to fetch category options:', catErr);
-        else {
-          setCategoryOptions(cats ?? []);
-          dispatch({
-            action: 'SET_CATEGORIES',
-            categories: (cats ?? []).filter(c => currentFilters.categories?.includes(c.id)),
-          });
-        }
-        if (pmErr) logger.error('Failed to fetch payment method options:', pmErr);
-        else {
-          setPaymentMethodOptions(pms ?? []);
-          dispatch({
-            action: 'SET_PAYMENT_METHODS',
-            paymentMethods: (pms ?? []).filter(pm => currentFilters.paymentMethods?.includes(pm.id)),
-          });
-        }
-      },
-    );
-  }, [open, currentFilters.categories?.includes, currentFilters.paymentMethods?.includes]);
+    dispatch({
+      action: 'SET_CATEGORIES',
+      categories: categoryOptions.filter(category => currentFilters.categories?.includes(category.id)),
+    });
+  }, [open, categoryOptions, currentFilters.categories]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    dispatch({
+      action: 'SET_PAYMENT_METHODS',
+      paymentMethods: paymentMethodOptions.filter(paymentMethod =>
+        currentFilters.paymentMethods?.includes(paymentMethod.id),
+      ),
+    });
+  }, [open, paymentMethodOptions, currentFilters.paymentMethods]);
 
   const onApplyFilters = () => {
     const result: Partial<EntityFilters> = {};
     if (withDateRange) {
       result.dateFrom = state.dateRange.startDate;
       result.dateTo = state.dateRange.endDate;
+    }
+    if (withRecurringPaymentStatus) {
+      result.paused = state.paused;
     }
     if (withExecuteDay) {
       result.executeFrom = clampDay(state.executeFrom);
@@ -104,20 +175,125 @@ export const FilterWrapper: React.FC<FilterWrapperProps> = ({
 
   const onFilterReset = () => {
     dispatch({action: 'RESET_ALL'});
-    onApply({dateFrom: null, dateTo: null, executeFrom: null, executeTo: null, categories: [], paymentMethods: []});
+    onApply({
+      dateFrom: null,
+      dateTo: null,
+      paused: null,
+      executeFrom: null,
+      executeTo: null,
+      categories: [],
+      paymentMethods: [],
+    });
     setOpen(false);
   };
 
   const hasActiveFilters = React.useMemo(() => {
     const hasDateRange = withDateRange && (!!currentFilters.dateFrom || !!currentFilters.dateTo);
+    const hasStatus = withRecurringPaymentStatus && currentFilters.paused != null;
     const hasExecuteDay = withExecuteDay && (currentFilters.executeFrom != null || currentFilters.executeTo != null);
     const hasCategories = withCategories && (currentFilters.categories?.length ?? 0) > 0;
     const hasPaymentMethods = withPaymentMethods && (currentFilters.paymentMethods?.length ?? 0) > 0;
-    return hasDateRange || hasExecuteDay || hasCategories || hasPaymentMethods;
-  }, [currentFilters, withExecuteDay, withDateRange, withCategories, withPaymentMethods]);
+    return hasDateRange || hasStatus || hasExecuteDay || hasCategories || hasPaymentMethods;
+  }, [currentFilters, withRecurringPaymentStatus, withExecuteDay, withDateRange, withCategories, withPaymentMethods]);
+
+  const applyQuickFilter = (filterValues: Partial<EntityFilters>) => {
+    onApply(filterValues);
+  };
+
+  const selectedTransactionDateQuickFilter =
+    transactionDateQuickFilters.find(filter => isTransactionDateQuickFilterActive(filter, currentFilters)) ?? '';
+  const selectedRecurringPaymentStatusQuickFilter =
+    recurringPaymentStatusQuickFilters.find(filter => currentFilters.paused === (filter === 'inactive')) ?? '';
+  const selectedRecurringPaymentExecutionQuickFilter =
+    recurringPaymentExecutionQuickFilters.find(filter =>
+      isRecurringPaymentExecutionQuickFilterActive(filter, currentFilters),
+    ) ?? '';
 
   return (
-    <React.Fragment>
+    <Stack
+      direction="row"
+      gap={1}
+      flexWrap="wrap"
+      alignItems="center"
+      sx={{py: 0.25, ml: 'auto', width: 'fit-content', maxWidth: '100%'}}
+    >
+      {transactionDateQuickFilters.length > 0 && (
+        <QuickFilterSelect
+          label="Time period"
+          resetLabel="All dates"
+          value={selectedTransactionDateQuickFilter}
+          options={transactionDateQuickFilters.map(filter => ({
+            value: filter,
+            label: transactionDateQuickFilterLabels[filter],
+          }))}
+          width={176}
+          onChange={filter =>
+            applyQuickFilter(
+              filter
+                ? getTransactionDateQuickFilterRange(filter as TransactionDateQuickFilter)
+                : {dateFrom: null, dateTo: null},
+            )
+          }
+        />
+      )}
+      {recurringPaymentStatusQuickFilters.length > 0 && (
+        <QuickFilterSelect
+          label="Status"
+          resetLabel="All statuses"
+          value={selectedRecurringPaymentStatusQuickFilter}
+          options={recurringPaymentStatusQuickFilters.map(filter => ({
+            value: filter,
+            label: recurringPaymentStatusQuickFilterLabels[filter],
+          }))}
+          width={148}
+          onChange={filter =>
+            applyQuickFilter(
+              filter
+                ? getRecurringPaymentStatusQuickFilter(filter as RecurringPaymentStatusQuickFilter)
+                : {paused: null},
+            )
+          }
+        />
+      )}
+      {recurringPaymentExecutionQuickFilters.length > 0 && (
+        <QuickFilterSelect
+          label="Execution"
+          resetLabel="All executions"
+          value={selectedRecurringPaymentExecutionQuickFilter}
+          options={recurringPaymentExecutionQuickFilters.map(filter => ({
+            value: filter,
+            label: recurringPaymentExecutionQuickFilterLabels[filter],
+          }))}
+          width={160}
+          onChange={filter =>
+            applyQuickFilter(
+              filter
+                ? getRecurringPaymentExecutionQuickFilter(filter as RecurringPaymentExecutionQuickFilter)
+                : {executeFrom: null, executeTo: null},
+            )
+          }
+        />
+      )}
+      {withCategories && (
+        <QuickFilterAutocomplete
+          label="Category"
+          value={currentFilters.categories ?? []}
+          options={categoryOptions.map(category => ({id: category.id, label: category.name}))}
+          loading={categoryOptionsLoading}
+          width={184}
+          onChange={categories => applyQuickFilter({categories})}
+        />
+      )}
+      {withPaymentMethods && (
+        <QuickFilterAutocomplete
+          label="Payment method"
+          value={currentFilters.paymentMethods ?? []}
+          options={paymentMethodOptions.map(paymentMethod => ({id: paymentMethod.id, label: paymentMethod.name}))}
+          loading={paymentMethodOptionsLoading}
+          width={216}
+          onChange={paymentMethods => applyQuickFilter({paymentMethods})}
+        />
+      )}
       <FilterButton isActive={hasActiveFilters} onClick={handleOpen} />
       <FilterDialog
         key={dialogKey}
@@ -126,6 +302,7 @@ export const FilterWrapper: React.FC<FilterWrapperProps> = ({
         onReset={onFilterReset}
         onApply={onApplyFilters}
         withDateRange={withDateRange}
+        withRecurringPaymentStatus={withRecurringPaymentStatus}
         withExecuteDay={withExecuteDay}
         withCategories={withCategories}
         withPaymentMethods={withPaymentMethods}
@@ -134,6 +311,6 @@ export const FilterWrapper: React.FC<FilterWrapperProps> = ({
         categoryOptions={categoryOptions}
         paymentMethodOptions={paymentMethodOptions}
       />
-    </React.Fragment>
+    </Stack>
   );
 };

--- a/apps/webapp/src/components/Filter/index.ts
+++ b/apps/webapp/src/components/Filter/index.ts
@@ -1,5 +1,7 @@
 export * from './FilterButton';
 export * from './FilterDialog';
 export * from './FilterReducer';
+export * from './QuickFilterAutocomplete';
+export * from './QuickFilterSelect';
 export * from './URLUtil';
 export * from './Wrapper';

--- a/apps/webapp/src/components/Filter/quickFilters.test.ts
+++ b/apps/webapp/src/components/Filter/quickFilters.test.ts
@@ -1,0 +1,82 @@
+import {describe, expect, it} from 'vitest';
+import {
+  getRecurringPaymentExecutionQuickFilter,
+  getRecurringPaymentStatusQuickFilter,
+  getTransactionDateQuickFilterRange,
+  isRecurringPaymentExecutionQuickFilterActive,
+  isTransactionDateQuickFilterActive,
+} from './quickFilters';
+
+describe('quickFilters', () => {
+  const referenceDate = new Date('2024-06-15T12:00:00.000Z');
+
+  it('builds the today transaction date range', () => {
+    expect(getTransactionDateQuickFilterRange('today', referenceDate)).toEqual({
+      dateFrom: referenceDate,
+      dateTo: referenceDate,
+    });
+  });
+
+  it('builds this month transaction date range', () => {
+    const result = getTransactionDateQuickFilterRange('thisMonth', referenceDate);
+    expect(result.dateFrom).toEqual(new Date(2024, 5, 1, 0, 0, 0, 0));
+    expect(result.dateTo).toEqual(new Date(2024, 5, 30, 23, 59, 59, 999));
+  });
+
+  it('builds last month transaction date range', () => {
+    const result = getTransactionDateQuickFilterRange('lastMonth', referenceDate);
+    expect(result.dateFrom).toEqual(new Date(2024, 4, 1, 0, 0, 0, 0));
+    expect(result.dateTo).toEqual(new Date(2024, 4, 31, 23, 59, 59, 999));
+  });
+
+  it('maps recurring payment status quick filters to paused filters', () => {
+    expect(getRecurringPaymentStatusQuickFilter('active')).toEqual({paused: false});
+    expect(getRecurringPaymentStatusQuickFilter('inactive')).toEqual({paused: true});
+  });
+
+  it('maps executed recurring payments to days before today in the current month', () => {
+    expect(getRecurringPaymentExecutionQuickFilter('executed', referenceDate)).toEqual({executeFrom: 1, executeTo: 14});
+  });
+
+  it('maps scheduled recurring payments to the remaining days of the current month', () => {
+    expect(getRecurringPaymentExecutionQuickFilter('scheduled', referenceDate)).toEqual({
+      executeFrom: 15,
+      executeTo: 30,
+    });
+  });
+
+  it('recognizes an active transaction date quick filter regardless of its time', () => {
+    expect(
+      isTransactionDateQuickFilterActive(
+        'thisMonth',
+        {
+          dateFrom: new Date('2024-06-01T00:00:00.000Z'),
+          dateTo: new Date('2024-06-30T00:00:00.000Z'),
+        },
+        referenceDate,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not mark a different transaction date range as active', () => {
+    expect(
+      isTransactionDateQuickFilterActive(
+        'thisMonth',
+        {
+          dateFrom: new Date('2024-06-02T00:00:00.000Z'),
+          dateTo: new Date('2024-06-30T00:00:00.000Z'),
+        },
+        referenceDate,
+      ),
+    ).toBe(false);
+  });
+
+  it('recognizes the active recurring payment execution quick filter', () => {
+    expect(
+      isRecurringPaymentExecutionQuickFilterActive('scheduled', {executeFrom: 15, executeTo: 30}, referenceDate),
+    ).toBe(true);
+    expect(
+      isRecurringPaymentExecutionQuickFilterActive('executed', {executeFrom: 15, executeTo: 30}, referenceDate),
+    ).toBe(false);
+  });
+});

--- a/apps/webapp/src/components/Filter/quickFilters.ts
+++ b/apps/webapp/src/components/Filter/quickFilters.ts
@@ -1,0 +1,77 @@
+import {endOfMonth, endOfWeek, startOfMonth, startOfWeek, subMonths} from 'date-fns';
+import type {EntityFilters} from '@/lib/features/createEntitySlice';
+
+export type TransactionDateQuickFilter = 'today' | 'thisWeek' | 'thisMonth' | 'lastMonth';
+export type RecurringPaymentStatusQuickFilter = 'active' | 'inactive';
+export type RecurringPaymentExecutionQuickFilter = 'executed' | 'scheduled';
+
+export function getTransactionDateQuickFilterRange(
+  filter: TransactionDateQuickFilter,
+  referenceDate: Date = new Date(),
+): Pick<EntityFilters, 'dateFrom' | 'dateTo'> {
+  switch (filter) {
+    case 'today':
+      return {dateFrom: referenceDate, dateTo: referenceDate};
+    case 'thisWeek':
+      return {
+        dateFrom: startOfWeek(referenceDate, {weekStartsOn: 1}),
+        dateTo: endOfWeek(referenceDate, {weekStartsOn: 1}),
+      };
+    case 'thisMonth':
+      return {dateFrom: startOfMonth(referenceDate), dateTo: endOfMonth(referenceDate)};
+    case 'lastMonth': {
+      const lastMonth = subMonths(referenceDate, 1);
+      return {dateFrom: startOfMonth(lastMonth), dateTo: endOfMonth(lastMonth)};
+    }
+  }
+}
+
+export function getRecurringPaymentStatusQuickFilter(
+  filter: RecurringPaymentStatusQuickFilter,
+): Pick<EntityFilters, 'paused'> {
+  return {paused: filter === 'inactive'};
+}
+
+export function getRecurringPaymentExecutionQuickFilter(
+  filter: RecurringPaymentExecutionQuickFilter,
+  referenceDate: Date = new Date(),
+): Pick<EntityFilters, 'executeFrom' | 'executeTo'> {
+  const today = referenceDate.getDate();
+  if (filter === 'executed') {
+    return {executeFrom: 1, executeTo: Math.max(1, today - 1)};
+  }
+  return {executeFrom: today, executeTo: endOfMonth(referenceDate).getDate()};
+}
+
+function isSameCalendarDate(left: Date | null | undefined, right: Date | null | undefined): boolean {
+  if (!left || !right) return left === right;
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+export function isTransactionDateQuickFilterActive(
+  filter: TransactionDateQuickFilter,
+  currentFilters: Partial<EntityFilters>,
+  referenceDate: Date = new Date(),
+): boolean {
+  const quickFilterRange = getTransactionDateQuickFilterRange(filter, referenceDate);
+  return (
+    isSameCalendarDate(currentFilters.dateFrom, quickFilterRange.dateFrom) &&
+    isSameCalendarDate(currentFilters.dateTo, quickFilterRange.dateTo)
+  );
+}
+
+export function isRecurringPaymentExecutionQuickFilterActive(
+  filter: RecurringPaymentExecutionQuickFilter,
+  currentFilters: Partial<EntityFilters>,
+  referenceDate: Date = new Date(),
+): boolean {
+  const quickFilterRange = getRecurringPaymentExecutionQuickFilter(filter, referenceDate);
+  return (
+    currentFilters.executeFrom === quickFilterRange.executeFrom &&
+    currentFilters.executeTo === quickFilterRange.executeTo
+  );
+}

--- a/apps/webapp/src/components/RecurringPayment/RecurringPaymentTable/RecurringPaymentTable.tsx
+++ b/apps/webapp/src/components/RecurringPayment/RecurringPaymentTable/RecurringPaymentTable.tsx
@@ -590,7 +590,10 @@ export const RecurringPaymentTable: React.FC<RecurringPaymentTableProps> = ({ini
             <FilterWrapper
               currentFilters={filters}
               onApply={handleFilterApply}
+              withRecurringPaymentStatus
               withExecuteDay
+              recurringPaymentStatusQuickFilters={['active', 'inactive']}
+              recurringPaymentExecutionQuickFilters={['executed', 'scheduled']}
               withCategories
               withPaymentMethods
             />

--- a/apps/webapp/src/components/Table/TableToolbar/TableToolbar.tsx
+++ b/apps/webapp/src/components/Table/TableToolbar/TableToolbar.tsx
@@ -124,10 +124,24 @@ export const TableToolbar: React.FC<TableToolbarProps & {isLoading?: boolean}> =
 
               return null;
             })}
-            {children}
           </ActionPaper>
         )}
       </Box>
+      {!isLoading && children && (
+        <Box
+          sx={theme => ({
+            width: 'calc(100% + 32px)',
+            mx: -2,
+            mt: 1.5,
+            px: 2,
+            py: 1.5,
+            borderTop: `1px solid ${theme.palette.divider}`,
+            borderBottom: `1px solid ${theme.palette.divider}`,
+          })}
+        >
+          {children}
+        </Box>
+      )}
     </Box>
   );
 };

--- a/apps/webapp/src/components/Transaction/TransactionTable/TransactionTable.tsx
+++ b/apps/webapp/src/components/Transaction/TransactionTable/TransactionTable.tsx
@@ -585,6 +585,7 @@ export const TransactionTable: React.FC<TransactionTableProps> = ({initialFilter
               currentFilters={filters}
               onApply={handleFilterApply}
               withDateRange
+              transactionDateQuickFilters={['today', 'thisWeek', 'thisMonth', 'lastMonth']}
               withCategories
               withPaymentMethods
             />

--- a/apps/webapp/src/lib/features/createEntitySlice/createEntitySlice.ts
+++ b/apps/webapp/src/lib/features/createEntitySlice/createEntitySlice.ts
@@ -21,6 +21,8 @@ export type EntityFilters = {
   paymentMethods?: string[];
   /** Shared: exclude these payment method IDs */
   excl_paymentMethods?: string[];
+  /** RecurringPayment-specific: paused state */
+  paused?: boolean | null;
   /** RecurringPayment-specific: execute day >= this value (1–31) */
   executeFrom?: number | null;
   /** RecurringPayment-specific: execute day <= this value (1–31) */

--- a/apps/webapp/src/lib/features/recurringPayments/recurringPaymentSlice.ts
+++ b/apps/webapp/src/lib/features/recurringPayments/recurringPaymentSlice.ts
@@ -9,6 +9,7 @@ export const recurringPaymentSlice = createEntitySlice(
   query => apiClient.backend.recurringPayment.getAll(query),
   filters => {
     const extra: Partial<IGetAllRecurringPaymentsQuery> = {};
+    if (filters.paused != null) extra.$paused = filters.paused;
     if (filters.executeFrom != null) extra.$executeFrom = filters.executeFrom;
     if (filters.executeTo != null) extra.$executeTo = filters.executeTo;
     if (filters.categories?.length) extra.$categories = filters.categories as TCategory['id'][];

--- a/packages/api/src/types/interfaces/recurringPayment.interface.ts
+++ b/packages/api/src/types/interfaces/recurringPayment.interface.ts
@@ -3,6 +3,7 @@ import type {TPaymentMethod} from '../paymentMethod.type';
 import type {IBaseGetAllQuery} from './query.interface';
 
 export interface IGetAllRecurringPaymentsQuery extends IBaseGetAllQuery {
+  $paused?: boolean;
   $executeFrom?: number;
   $executeTo?: number;
   $categories?: TCategory['id'][];

--- a/services/backend/src/router/assembleFilter.ts
+++ b/services/backend/src/router/assembleFilter.ts
@@ -11,7 +11,7 @@ export type TSearchFilter<Table extends TableConfig> = {
   searchableColumnName?: (keyof Table['columns'])[];
 };
 
-type TBaseValue = string | number | Date;
+type TBaseValue = string | number | boolean | Date;
 
 export type TAdditionalFilter<Table extends TableConfig> =
   | {

--- a/services/backend/src/router/recurringPayment.router.ts
+++ b/services/backend/src/router/recurringPayment.router.ts
@@ -19,6 +19,7 @@ recurringPaymentRouter.get(
       search: z.string().optional(),
       from: z.coerce.number().optional(),
       to: z.coerce.number().optional(),
+      $paused: z.coerce.boolean().optional(),
       $executeFrom: z.coerce.number().min(1).max(31).optional(),
       $executeTo: z.coerce.number().min(1).max(31).optional(),
       $categories: z
@@ -52,6 +53,9 @@ recurringPaymentRouter.get(
 
     const query = req.query;
     const additionalFilters: TAdditionalFilter<(typeof recurringPayments)['_']['config']>[] = [];
+    if (query.$paused !== undefined) {
+      additionalFilters.push({columnName: 'paused', operator: 'eq', value: query.$paused});
+    }
     if (query.$executeFrom) {
       additionalFilters.push({columnName: 'executeAt', operator: 'gte', value: query.$executeFrom});
     }


### PR DESCRIPTION
### Motivation
- Provide users with quick, one-click filters for Transactions and Recurring Payments while reusing the existing filter workflow and URL/Redux integration.
- Keep UI logic covered by unit tests and avoid duplicating filter logic across tables and dialogs.

### Description
- Added reusable quick-filter helpers in `apps/webapp/src/components/Filter/quickFilters.ts` to map quick selections to `EntityFilters` (transaction date ranges, recurring payment status and execution ranges).
- Exposed quick-filter chips in the shared `FilterWrapper` (`apps/webapp/src/components/Filter/Wrapper.tsx`) which call the same `onApply` path; integrated quick filters into the Transactions and Recurring Payments table toolbars.
- Extended filter state and dialog to support recurring-payment `paused`/status: updated `FilterReducer`, `FilterDialog`, `URLUtil` serialization/parsing, and `EntityFilters` (`createEntitySlice`) to include `paused`.
- Wired `paused` through the frontend slice to the API by adding `$paused` handling in `recurringPaymentSlice` and backend support in `services/backend/src/router/recurringPayment.router.ts`, and allowed boolean values in `assembleFilter` types.
- Added unit tests `quickFilters.test.ts` for the mapping helpers and updated `URLUtil.spec.ts` to cover `paused` serialization/parsing.

### Testing
- Ran unit tests with Vitest: `npm --workspace @budgetbuddyde/webapp exec vitest run --silent src/components/Filter/quickFilters.test.ts src/components/Filter/URLUtil/URLUtil.spec.ts`, and the tests passed (2 files, 59 tests total).
- Lint checks were executed for both webapp and backend (`npm run lint:check`) and completed; any tooling warnings unrelated to the new code were reported separately.
- Type checks were executed (`npm --workspace @budgetbuddyde/webapp run typecheck` and `npm --workspace @budgetbuddyde/backend run typecheck`) and failed in this environment due to workspace package/type resolution issues unrelated to the changes (missing workspace package typings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5644430b848322b9fdd91c3b831852)