### PR TITLE
Paginate transaction attachments, add incremental loading and upload safeguards

### DIFF
--- a/apps/webapp/README.md
+++ b/apps/webapp/README.md
@@ -45,3 +45,9 @@ To learn more about this example:
 
 You now have a working example project.
 You can head back to the documentation and continue by browsing the [templates](https://mui.com/material-ui/getting-started/templates/) section.
+
+## Transaction attachment loading
+
+The transaction attachment dialog loads attachments incrementally in pages of 24. This keeps large transactions responsive by avoiding upfront rendering of every thumbnail and by only requesting signed URLs for the current page. Users can fetch additional pages with the "Load more attachments" action.
+
+The transaction table uses the backend-provided `attachmentCount` plus a small preview strip, so the table stays fast even when a transaction has many attachments.

--- a/apps/webapp/src/components/Transaction/Attachments/PreviewStrip/TransactionAttachmentPreviewStrip.tsx
+++ b/apps/webapp/src/components/Transaction/Attachments/PreviewStrip/TransactionAttachmentPreviewStrip.tsx
@@ -14,12 +14,14 @@ export type TransactionAttachmentPreviewStripProps = {
 
 export const TransactionAttachmentPreviewStrip: React.FC<TransactionAttachmentPreviewStripProps> = ({
   attachments = [],
+  attachmentCount,
   previewLimit = 3,
   onClick,
 }) => {
-  if (attachments.length <= 0) return null;
+  const totalAttachments = attachmentCount ?? attachments.length;
+  if (totalAttachments <= 0) return null;
   const avatarContent = (
-    <AvatarGroup max={previewLimit} total={attachments.length}>
+    <AvatarGroup max={previewLimit} total={totalAttachments}>
       {attachments.length > 0 ? (
         attachments.map(attachment => (
           <Avatar key={attachment.id} src={attachment.signedUrl} alt={attachment.fileName} variant="rounded" />
@@ -39,7 +41,7 @@ export const TransactionAttachmentPreviewStrip: React.FC<TransactionAttachmentPr
         event.stopPropagation();
         onClick();
       }}
-      aria-label={`Open ${attachments.length} transaction attachments`}
+      aria-label={`Open ${totalAttachments} transaction attachments`}
       sx={{
         borderRadius: 1.25,
         justifyContent: 'flex-start',

--- a/apps/webapp/src/components/Transaction/Attachments/TransactionAttachments.test.tsx
+++ b/apps/webapp/src/components/Transaction/Attachments/TransactionAttachments.test.tsx
@@ -58,7 +58,7 @@ describe('TransactionAttachments', () => {
 
   it('renders the upload zone', async () => {
     vi.mocked(apiClient.backend.transaction.getTransactionAttachments).mockResolvedValue([
-      {data: [], message: 'ok', status: 200, from: 'db'},
+      {data: [], totalCount: 0, message: 'ok', status: 200, from: 'db'},
       null,
     ]);
 
@@ -71,7 +71,7 @@ describe('TransactionAttachments', () => {
 
   it('shows "No attachments yet" when there are no attachments', async () => {
     vi.mocked(apiClient.backend.transaction.getTransactionAttachments).mockResolvedValue([
-      {data: [], message: 'ok', status: 200, from: 'db'},
+      {data: [], totalCount: 0, message: 'ok', status: 200, from: 'db'},
       null,
     ]);
 
@@ -87,7 +87,7 @@ describe('TransactionAttachments', () => {
   it('renders attachment thumbnails when attachments exist', async () => {
     const attachments = [makeAttachment('att-1'), makeAttachment('att-2')];
     vi.mocked(apiClient.backend.transaction.getTransactionAttachments).mockResolvedValue([
-      {data: attachments, message: 'ok', status: 200, from: 'db'},
+      {data: attachments, totalCount: attachments.length, message: 'ok', status: 200, from: 'db'},
       null,
     ]);
 
@@ -101,10 +101,39 @@ describe('TransactionAttachments', () => {
     });
   });
 
+  it('loads attachments page-by-page', async () => {
+    const firstPage = [makeAttachment('page-1')];
+    const secondPage = [makeAttachment('page-2')];
+    vi.mocked(apiClient.backend.transaction.getTransactionAttachments)
+      .mockResolvedValueOnce([{data: firstPage, totalCount: 2, message: 'ok', status: 200, from: 'db'}, null])
+      .mockResolvedValueOnce([{data: secondPage, totalCount: 2, message: 'ok', status: 200, from: 'db'}, null]);
+
+    await act(async () => {
+      render(<TransactionAttachments transactionId={TX_ID} />);
+    });
+
+    await waitFor(() => screen.getByText('file-page-1.png'));
+    expect(screen.getByText(/showing 1 of 2 attachments/i)).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', {name: /load more attachments/i}));
+    });
+
+    await waitFor(() => screen.getByText('file-page-2.png'));
+    expect(apiClient.backend.transaction.getTransactionAttachments).toHaveBeenNthCalledWith(1, TX_ID, {
+      from: 0,
+      to: 24,
+    });
+    expect(apiClient.backend.transaction.getTransactionAttachments).toHaveBeenNthCalledWith(2, TX_ID, {
+      from: 1,
+      to: 25,
+    });
+  });
+
   it('opens the lightbox when View is clicked', async () => {
     const attachment = makeAttachment('att-view');
     vi.mocked(apiClient.backend.transaction.getTransactionAttachments).mockResolvedValue([
-      {data: [attachment], message: 'ok', status: 200, from: 'db'},
+      {data: [attachment], totalCount: 1, message: 'ok', status: 200, from: 'db'},
       null,
     ]);
 
@@ -127,7 +156,7 @@ describe('TransactionAttachments', () => {
   it('opens delete confirmation when Delete is clicked', async () => {
     const attachment = makeAttachment('att-del');
     vi.mocked(apiClient.backend.transaction.getTransactionAttachments).mockResolvedValue([
-      {data: [attachment], message: 'ok', status: 200, from: 'db'},
+      {data: [attachment], totalCount: 1, message: 'ok', status: 200, from: 'db'},
       null,
     ]);
 
@@ -148,7 +177,7 @@ describe('TransactionAttachments', () => {
   it('calls deleteTransactionAttachments when delete is confirmed', async () => {
     const attachment = makeAttachment('att-confirm');
     vi.mocked(apiClient.backend.transaction.getTransactionAttachments).mockResolvedValue([
-      {data: [attachment], message: 'ok', status: 200, from: 'db'},
+      {data: [attachment], totalCount: 1, message: 'ok', status: 200, from: 'db'},
       null,
     ]);
     vi.mocked(apiClient.backend.transaction.deleteTransactionAttachments).mockResolvedValueOnce([
@@ -178,7 +207,7 @@ describe('TransactionAttachments', () => {
 
   it('renders the file input with correct accept attribute', async () => {
     vi.mocked(apiClient.backend.transaction.getTransactionAttachments).mockResolvedValue([
-      {data: [], message: 'ok', status: 200, from: 'db'},
+      {data: [], totalCount: 0, message: 'ok', status: 200, from: 'db'},
       null,
     ]);
 
@@ -194,11 +223,11 @@ describe('TransactionAttachments', () => {
 
   it('calls uploadTransactionAttachments when a file is selected', async () => {
     vi.mocked(apiClient.backend.transaction.getTransactionAttachments).mockResolvedValue([
-      {data: [], message: 'ok', status: 200, from: 'db'},
+      {data: [], totalCount: 0, message: 'ok', status: 200, from: 'db'},
       null,
     ]);
     vi.mocked(apiClient.backend.transaction.uploadTransactionAttachments).mockResolvedValueOnce([
-      {data: [], message: 'uploaded', status: 201, from: 'db'},
+      {data: [], totalCount: 0, message: 'uploaded', status: 201, from: 'db'},
       null,
     ]);
 

--- a/apps/webapp/src/components/Transaction/Attachments/TransactionAttachments.tsx
+++ b/apps/webapp/src/components/Transaction/Attachments/TransactionAttachments.tsx
@@ -2,7 +2,7 @@
 
 import type {TTransaction} from '@budgetbuddyde/api/transaction';
 import {AttachFileRounded} from '@mui/icons-material';
-import {Box, Grid, Skeleton} from '@mui/material';
+import {Box, Button, Grid, Skeleton, Typography} from '@mui/material';
 import type React from 'react';
 import {AttachmentLightbox, AttachmentThumbnail, FileDropZone} from '@/components/Attachments';
 import {DeleteDialog} from '@/components/Dialog';
@@ -23,8 +23,19 @@ export type TransactionAttachmentsProps = {
  * {@link AttachmentLightbox}, and `DeleteDialog`.
  */
 export const TransactionAttachments: React.FC<TransactionAttachmentsProps> = ({transactionId}) => {
-  const {state, dispatch, handleUpload, handleDownload, handleDeleteConfirm} = useTransactionAttachments(transactionId);
-  const {attachments, isLoading, isUploading, isDragging, viewedAttachment, deletingAttachmentId} = state;
+  const {state, dispatch, handleUpload, handleDownload, handleDeleteConfirm, handleLoadMore} =
+    useTransactionAttachments(transactionId);
+  const {
+    attachments,
+    totalCount,
+    isLoading,
+    isLoadingMore,
+    isUploading,
+    isDragging,
+    viewedAttachment,
+    deletingAttachmentId,
+  } = state;
+  const hasMoreAttachments = attachments.length < totalCount;
 
   return (
     <Box>
@@ -54,18 +65,31 @@ export const TransactionAttachments: React.FC<TransactionAttachmentsProps> = ({t
           ))}
         </Grid>
       ) : attachments.length > 0 ? (
-        <Grid container spacing={1}>
-          {attachments.map(attachment => (
-            <Grid key={attachment.id} size={{xs: 6, sm: 4}}>
-              <AttachmentThumbnail
-                attachment={attachment}
-                onView={a => dispatch({type: 'VIEW_OPEN', attachment: a})}
-                onDownload={handleDownload}
-                onDelete={a => dispatch({type: 'DELETE_OPEN', attachmentId: a.id})}
-              />
-            </Grid>
-          ))}
-        </Grid>
+        <>
+          <Typography variant="body2" color="text.secondary" sx={{mb: 1}}>
+            Showing {attachments.length} of {totalCount} attachments
+          </Typography>
+          <Grid container spacing={1}>
+            {attachments.map((attachment, index) => (
+              <Grid key={attachment.id} size={{xs: 6, sm: 4}}>
+                <AttachmentThumbnail
+                  attachment={attachment}
+                  priority={index < 6}
+                  onView={a => dispatch({type: 'VIEW_OPEN', attachment: a})}
+                  onDownload={handleDownload}
+                  onDelete={a => dispatch({type: 'DELETE_OPEN', attachmentId: a.id})}
+                />
+              </Grid>
+            ))}
+          </Grid>
+          {hasMoreAttachments && (
+            <Box sx={{display: 'flex', justifyContent: 'center', mt: 2}}>
+              <Button variant="outlined" loading={isLoadingMore} onClick={handleLoadMore}>
+                Load more attachments
+              </Button>
+            </Box>
+          )}
+        </>
       ) : (
         <NoResults icon={<AttachFileRounded />} text={'No attachments yet'} />
       )}

--- a/apps/webapp/src/components/Transaction/Attachments/transactionAttachmentsReducer.ts
+++ b/apps/webapp/src/components/Transaction/Attachments/transactionAttachmentsReducer.ts
@@ -3,7 +3,9 @@ import type {TAttachmentWithUrl} from '@budgetbuddyde/api/attachment';
 /** Represents the complete UI and data state for the transaction attachments feature. */
 export type TransactionAttachmentsState = {
   attachments: TAttachmentWithUrl[];
+  totalCount: number;
   isLoading: boolean;
+  isLoadingMore: boolean;
   isUploading: boolean;
   isDragging: boolean;
   viewedAttachment: TAttachmentWithUrl | null;
@@ -13,7 +15,8 @@ export type TransactionAttachmentsState = {
 /** Union of all actions that can be dispatched to update {@link TransactionAttachmentsState}. */
 export type TransactionAttachmentsAction =
   | {type: 'LOAD_START'}
-  | {type: 'LOAD_SUCCESS'; attachments: TAttachmentWithUrl[]}
+  | {type: 'LOAD_MORE_START'}
+  | {type: 'LOAD_SUCCESS'; attachments: TAttachmentWithUrl[]; totalCount: number; append?: boolean}
   | {type: 'LOAD_ERROR'}
   | {type: 'UPLOAD_START'}
   | {type: 'UPLOAD_SUCCESS'; newAttachments: TAttachmentWithUrl[]}
@@ -28,7 +31,9 @@ export type TransactionAttachmentsAction =
 /** Initial state used when the hook is first mounted. */
 export const transactionAttachmentsInitialState: TransactionAttachmentsState = {
   attachments: [],
+  totalCount: 0,
   isLoading: true,
+  isLoadingMore: false,
   isUploading: false,
   isDragging: false,
   viewedAttachment: null,
@@ -46,14 +51,27 @@ export function transactionAttachmentsReducer(
   switch (action.type) {
     case 'LOAD_START':
       return {...state, isLoading: true};
+    case 'LOAD_MORE_START':
+      return {...state, isLoadingMore: true};
     case 'LOAD_SUCCESS':
-      return {...state, isLoading: false, attachments: action.attachments};
+      return {
+        ...state,
+        isLoading: false,
+        isLoadingMore: false,
+        attachments: action.append ? [...state.attachments, ...action.attachments] : action.attachments,
+        totalCount: action.totalCount,
+      };
     case 'LOAD_ERROR':
-      return {...state, isLoading: false};
+      return {...state, isLoading: false, isLoadingMore: false};
     case 'UPLOAD_START':
       return {...state, isUploading: true};
     case 'UPLOAD_SUCCESS':
-      return {...state, isUploading: false, attachments: [...state.attachments, ...action.newAttachments]};
+      return {
+        ...state,
+        isUploading: false,
+        attachments: [...action.newAttachments, ...state.attachments],
+        totalCount: state.totalCount + action.newAttachments.length,
+      };
     case 'UPLOAD_ERROR':
       return {...state, isUploading: false};
     case 'SET_DRAGGING':
@@ -70,6 +88,7 @@ export function transactionAttachmentsReducer(
       return {
         ...state,
         deletingAttachmentId: null,
+        totalCount: Math.max(0, state.totalCount - 1),
         attachments: state.attachments.filter(a => a.id !== action.attachmentId),
       };
     default:

--- a/apps/webapp/src/components/Transaction/Attachments/useTransactionAttachments.ts
+++ b/apps/webapp/src/components/Transaction/Attachments/useTransactionAttachments.ts
@@ -6,10 +6,10 @@ import type {TTransaction} from '@budgetbuddyde/api/transaction';
 import React from 'react';
 import {apiClient} from '@/apiClient';
 import {useSnackbarContext} from '@/components/Snackbar';
-import {useFetch} from '@/hooks/useFetch';
 import {transactionAttachmentsInitialState, transactionAttachmentsReducer} from './transactionAttachmentsReducer';
 
 const ALLOWED_CONTENT_TYPES = new Set<string>(ATTACHMENT_CONTENT_TYPES);
+const ATTACHMENT_PAGE_SIZE = 24;
 
 /** Extensions that browsers may report as `application/octet-stream` but are valid image types. */
 const OCTET_STREAM_ALLOWED_EXTENSIONS = new Set(['heic', 'heif']);
@@ -25,37 +25,45 @@ function isAllowedFileType(file: File): boolean {
 
 /**
  * Manages all state and async operations for a transaction's attachments.
- *
- * Provides:
- * - `state` – current {@link TransactionAttachmentsState} (via `useReducer`)
- * - `dispatch` – raw dispatcher to trigger state transitions directly
- * - `handleUpload` – uploads one or more files and appends them to the list
- * - `handleDownload` – triggers a browser download for a given attachment
- * - `handleDeleteConfirm` – deletes the attachment stored in `state.deletingAttachmentId`
+ * Attachments are loaded page-by-page to avoid generating signed URLs and
+ * rendering image cards for large attachment collections upfront.
  *
  * @param transactionId - The ID of the transaction whose attachments are managed.
  */
 export function useTransactionAttachments(transactionId: TTransaction['id']) {
   const {showSnackbar} = useSnackbarContext();
   const [state, dispatch] = React.useReducer(transactionAttachmentsReducer, transactionAttachmentsInitialState);
-  const fetchAttachments = React.useCallback(async () => {
-    const [result, error] = await apiClient.backend.transaction.getTransactionAttachments(transactionId);
-    if (error) {
-      dispatch({type: 'LOAD_ERROR'});
-      showSnackbar({message: `Failed to load attachments: ${error.message}`});
-      return [];
-    }
-    return result.data ?? [];
-  }, [transactionId, showSnackbar]);
 
-  const {isLoading, data: fetchedAttachments} = useFetch<TAttachmentWithUrl[]>(fetchAttachments);
+  const fetchAttachments = React.useCallback(
+    async (from = 0, append = false) => {
+      dispatch({type: append ? 'LOAD_MORE_START' : 'LOAD_START'});
+      const [result, error] = await apiClient.backend.transaction.getTransactionAttachments(transactionId, {
+        from,
+        to: from + ATTACHMENT_PAGE_SIZE,
+      });
+      if (error) {
+        dispatch({type: 'LOAD_ERROR'});
+        showSnackbar({message: `Failed to load attachments: ${error.message}`});
+        return;
+      }
+      dispatch({
+        type: 'LOAD_SUCCESS',
+        attachments: result.data ?? [],
+        totalCount: result.totalCount ?? result.data?.length ?? 0,
+        append,
+      });
+    },
+    [transactionId, showSnackbar],
+  );
 
-  // Sync fetched attachments into the reducer whenever useFetch delivers new data
   React.useEffect(() => {
-    if (fetchedAttachments !== null) {
-      dispatch({type: 'LOAD_SUCCESS', attachments: fetchedAttachments});
-    }
-  }, [fetchedAttachments]);
+    void fetchAttachments(0, false);
+  }, [fetchAttachments]);
+
+  const handleLoadMore = React.useCallback(() => {
+    if (state.isLoading || state.isLoadingMore || state.attachments.length >= state.totalCount) return;
+    void fetchAttachments(state.attachments.length, true);
+  }, [fetchAttachments, state.attachments.length, state.isLoading, state.isLoadingMore, state.totalCount]);
 
   const handleUpload = React.useCallback(
     async (files: File[]) => {
@@ -82,7 +90,6 @@ export function useTransactionAttachments(transactionId: TTransaction['id']) {
   );
 
   const handleDownload = React.useCallback((attachment: TAttachmentWithUrl) => {
-    // TODO: Rethink if we rather just download the file instead of redirecting the user
     const anchor = document.createElement('a');
     anchor.href = attachment.signedUrl;
     anchor.download = attachment.fileName;
@@ -108,6 +115,5 @@ export function useTransactionAttachments(transactionId: TTransaction['id']) {
     showSnackbar({message: 'Attachment deleted'});
   }, [state.deletingAttachmentId, transactionId, showSnackbar]);
 
-  // isLoading from useFetch takes precedence over the reducer's initial value
-  return {state: {...state, isLoading}, dispatch, handleUpload, handleDownload, handleDeleteConfirm};
+  return {state, dispatch, handleUpload, handleDownload, handleDeleteConfirm, handleLoadMore};
 }

--- a/packages/api/src/types/interfaces/attachment.interface.ts
+++ b/packages/api/src/types/interfaces/attachment.interface.ts
@@ -1,3 +1,5 @@
 export interface IGetAllAttachmentsQuery {
+  from?: number;
+  to?: number;
   ttl?: number;
 }

--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -25,3 +25,12 @@ npm start
 
 - [ExpressJS](https://expressjs.com/)
 - [Drizzle ORM](https://orm.drizzle.team/)
+
+## Attachment performance and safety
+
+Transaction attachment endpoints are optimized for large attachment collections:
+
+- `GET /api/transaction/:id/attachments` is paginated. When no range is supplied, the backend returns the first 24 attachments and caps each request at 100 attachments.
+- `GET /api/transaction` returns only a small signed-url preview per transaction while still returning `attachmentCount` for the full count.
+- Uploads are protected with server-side limits of 10 files per request and 10 MiB per file. The backend validates attachment content types and only accepts the configured image formats.
+- Signed URLs remain short-lived and are generated only for the attachments that are actually returned to the client.

--- a/services/backend/src/__tests__/attachment.handler.test.ts
+++ b/services/backend/src/__tests__/attachment.handler.test.ts
@@ -373,6 +373,27 @@ suite('TransactionAttachmentHandler.findTransactionAttachmentsByOwner', () => {
     expect(result.totalCount).toBe(0);
   });
 
+  it('caps requested page size to avoid generating too many signed URLs', async () => {
+    const mockCountChain = {
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue([{count: 250}]),
+    };
+    const mockLimit = vi.fn().mockResolvedValue([]);
+    const mockRecordsChain = {
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockReturnThis(),
+      limit: mockLimit,
+    };
+    mockDbSelect.mockReturnValueOnce(mockCountChain).mockReturnValueOnce(mockRecordsChain);
+
+    await handler.findTransactionAttachmentsByOwner(USER_ID, {from: 0, to: 250});
+
+    expect(mockLimit).toHaveBeenCalledWith(100);
+  });
+
   it('returns attachments with signed URLs when records exist', async () => {
     const record = {
       id: ATTACHMENT_ID,

--- a/services/backend/src/lib/attachment/transaction-attachment.handler.ts
+++ b/services/backend/src/lib/attachment/transaction-attachment.handler.ts
@@ -23,6 +23,15 @@ type PaginationQuery = {
   ttl?: number;
 };
 
+const DEFAULT_ATTACHMENT_PAGE_SIZE = 24;
+const MAX_ATTACHMENT_PAGE_SIZE = 100;
+
+function getPaginationWindow({from = 0, to}: PaginationQuery): {from: number; limit: number} {
+  const normalizedFrom = Math.max(0, from);
+  const requestedLimit = to !== undefined ? Math.max(0, to - normalizedFrom) : DEFAULT_ATTACHMENT_PAGE_SIZE;
+  return {from: normalizedFrom, limit: Math.min(requestedLimit, MAX_ATTACHMENT_PAGE_SIZE)};
+}
+
 export class TransactionAttachmentHandler extends AttachmentHandler {
   private generateAttachmentStoragePath(
     userId: string,
@@ -109,8 +118,8 @@ export class TransactionAttachmentHandler extends AttachmentHandler {
     userId: string,
     query: PaginationQuery = {},
   ): Promise<{attachments: AttachmentWithSignedUrl[]; totalCount: number}> {
-    const {from = 0, to, ttl} = query;
-    const limit = to !== undefined ? to - from : 50;
+    const {ttl} = query;
+    const {from, limit} = getPaginationWindow(query);
 
     const [totalCountResult, records] = await Promise.all([
       db
@@ -168,8 +177,8 @@ export class TransactionAttachmentHandler extends AttachmentHandler {
     transactionId: string,
     query: PaginationQuery = {},
   ): Promise<{attachments: AttachmentWithSignedUrl[]; totalCount: number}> {
-    const {from = 0, to, ttl} = query;
-    const limit = to !== undefined ? to - from : 50;
+    const {ttl} = query;
+    const {from, limit} = getPaginationWindow(query);
 
     const ownerAndTransaction = and(
       eq(attachments.ownerId, userId),

--- a/services/backend/src/router/transaction.router.ts
+++ b/services/backend/src/router/transaction.router.ts
@@ -1,5 +1,10 @@
 import type {TUserID} from '@budgetbuddyde/api';
-import {SignedAttachmentUrlTTL, type TAttachment, type TAttachmentWithUrl} from '@budgetbuddyde/api/attachment';
+import {
+  ATTACHMENT_CONTENT_TYPES,
+  SignedAttachmentUrlTTL,
+  type TAttachment,
+  type TAttachmentWithUrl,
+} from '@budgetbuddyde/api/attachment';
 import {Category} from '@budgetbuddyde/api/category';
 import {PaymentMethod} from '@budgetbuddyde/api/paymentMethod';
 import {
@@ -23,9 +28,29 @@ import {ApiResponse, HTTPStatusCode} from '../models';
 import {assembleFilter, type TAdditionalFilter} from './assembleFilter';
 
 export const transactionRouter = Router();
-const upload = multer({storage: multer.memoryStorage()});
+const MAX_ATTACHMENT_FILES_PER_REQUEST = 10;
+const MAX_ATTACHMENT_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const TRANSACTION_ATTACHMENT_PREVIEW_LIMIT = 3;
+const ALLOWED_ATTACHMENT_CONTENT_TYPES = new Set<string>(ATTACHMENT_CONTENT_TYPES);
+const OCTET_STREAM_ALLOWED_EXTENSIONS = new Set(['heic', 'heif']);
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    files: MAX_ATTACHMENT_FILES_PER_REQUEST,
+    fileSize: MAX_ATTACHMENT_FILE_SIZE_BYTES,
+  },
+});
 const attachmentLogger = logger.child({label: 'transactions.attachments'});
 const attachmentService = new TransactionAttachmentHandler(process.env.AWS_S3_BUCKET_NAME as string);
+
+const isAllowedAttachmentFile = (file: Express.Multer.File): boolean => {
+  if (ALLOWED_ATTACHMENT_CONTENT_TYPES.has(file.mimetype)) return true;
+  if (file.mimetype === 'application/octet-stream') {
+    const extension = file.originalname.split('.').pop()?.toLowerCase() ?? '';
+    return OCTET_STREAM_ALLOWED_EXTENSIONS.has(extension);
+  }
+  return false;
+};
 
 const mapAttachmentWithUrl = (attachment: {
   id: string;
@@ -204,16 +229,18 @@ transactionRouter.get(
         attachmentCountByTransactionId.set(transactionId, (attachmentCountByTransactionId.get(transactionId) ?? 0) + 1);
 
         const previewRows = previewRowsByTransactionId.get(transactionId) ?? [];
-        previewRows.push({
-          id: attachmentRow.id,
-          ownerId: attachmentRow.ownerId,
-          fileName: attachmentRow.fileName,
-          fileExtension: attachmentRow.fileExtension,
-          contentType: attachmentRow.contentType,
-          location: attachmentRow.location,
-          createdAt: attachmentRow.createdAt,
-        });
-        previewRowsByTransactionId.set(transactionId, previewRows);
+        if (previewRows.length < TRANSACTION_ATTACHMENT_PREVIEW_LIMIT) {
+          previewRows.push({
+            id: attachmentRow.id,
+            ownerId: attachmentRow.ownerId,
+            fileName: attachmentRow.fileName,
+            fileExtension: attachmentRow.fileExtension,
+            contentType: attachmentRow.contentType,
+            location: attachmentRow.location,
+            createdAt: attachmentRow.createdAt,
+          });
+          previewRowsByTransactionId.set(transactionId, previewRows);
+        }
       }
     }
 
@@ -437,7 +464,7 @@ transactionRouter.post(
 
 transactionRouter.post(
   '/:id/attachments',
-  upload.array('files'),
+  upload.array('files', MAX_ATTACHMENT_FILES_PER_REQUEST),
   validateRequest({
     params: z.object({
       id: TransactionSchemas.select.shape.id,
@@ -460,8 +487,16 @@ transactionRouter.post(
         .buildAndSend(res);
     }
 
+    const invalidFiles = files.filter(file => !isAllowedAttachmentFile(file));
+    if (invalidFiles.length > 0) {
+      return ApiResponse.builder()
+        .withStatus(HTTPStatusCode.BAD_REQUEST)
+        .withMessage('Unsupported attachment file type')
+        .buildAndSend(res);
+    }
+
     try {
-      const transactionId = req.params.id;
+      const transactionId = req.params.id as string;
       const uploadedAttachments = await attachmentService.uploadTransactionAttachments(userId, transactionId, files);
 
       ApiResponse.builder<TAttachmentWithUrl[]>()


### PR DESCRIPTION
### Motivation

- Prevent large transactions from becoming unresponsive by avoiding upfront rendering and signed-URL generation for every attachment.  
- Surface a small preview strip with the backend-provided total count while enabling users to fetch additional attachments on demand.  
- Harden the backend by capping page sizes, validating uploaded file types, and enforcing per-request/file size limits.

### Description

- Implemented page-by-page loading in `useTransactionAttachments` with `ATTACHMENT_PAGE_SIZE = 24`, added `handleLoadMore`, and wired it into `TransactionAttachments` which now shows `Showing X of Y attachments` and a `Load more attachments` button.  
- Extended the reducer with `totalCount` and `isLoadingMore`, added `LOAD_MORE_START`, made `UPLOAD_SUCCESS` update `totalCount`, and ensured deletes decrement `totalCount`.  
- Updated `TransactionAttachmentPreviewStrip` to prefer the backend `attachmentCount` for avatar totals and improved ARIA labeling to reflect the total.  
- Backend additions include `from`/`to` pagination query support in API types, a `getPaginationWindow` helper that enforces defaults and a `MAX_ATTACHMENT_PAGE_SIZE` cap (100), preview capping for transaction lists, multer upload limits (max files and file size), and server-side file-type checks for uploads.  
- Updated READMEs to document the incremental loading behavior and backend attachment limits, and added/updated unit tests to cover paginated loading and server-side caps.

### Testing

- Ran frontend unit tests including `TransactionAttachments.test.tsx` which were updated to expect `totalCount` and the new incremental loading flow, and they passed.  
- Ran backend unit tests including `attachment.handler.test.ts` which include the new page-size cap test, and they passed.  
- Ran the project's automated test suite for modified packages and no regressions were detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56c0efbd848322a4ce5db53f1a7f3c)