### PR TITLE
Optimize attachments before S3 upload: image resizing and gzip compression, add sharp dependency and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2885,7 +2885,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -8514,7 +8513,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -13636,7 +13634,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -13680,7 +13677,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -16705,6 +16701,7 @@
         "node-cron": "^4.2.1",
         "pg": "^8.16.1",
         "rate-limit-redis": "^4.3.1",
+        "sharp": "^0.34.5",
         "uuidv7": "^1.1.0",
         "winston": "^3.19.0",
         "winston-loki": "^6.1.3",

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -52,6 +52,7 @@
     "node-cron": "^4.2.1",
     "pg": "^8.16.1",
     "rate-limit-redis": "^4.3.1",
+    "sharp": "^0.34.5",
     "uuidv7": "^1.1.0",
     "winston": "^3.19.0",
     "winston-loki": "^6.1.3",

--- a/services/backend/src/__tests__/attachment.handler.test.ts
+++ b/services/backend/src/__tests__/attachment.handler.test.ts
@@ -1,3 +1,4 @@
+import sharp from 'sharp';
 import {beforeEach, describe, expect, it, suite, vi} from 'vitest';
 
 // ---------------------------------------------------------------------------
@@ -111,6 +112,49 @@ const ATTACHMENT_ID = '01926a0b-0000-7000-8000-000000000001';
 // ---------------------------------------------------------------------------
 
 suite('AttachmentHandler', () => {
+  describe('prepareAttachmentBuffer', () => {
+    it('gzip-compresses non-image buffers when the compressed payload is smaller', async () => {
+      const buffer = Buffer.from('receipt-data-'.repeat(100));
+
+      const prepared = await AttachmentHandler.prepareAttachmentBuffer(buffer, 'application/pdf');
+
+      expect(prepared.contentEncoding).toBe('gzip');
+      expect(prepared.optimization).toBe('gzip');
+      expect(prepared.buffer.length).toBeLessThan(buffer.length);
+    });
+
+    it('keeps original non-image buffers when gzip would not reduce the payload size', async () => {
+      const buffer = Buffer.from([0x1f]);
+
+      const prepared = await AttachmentHandler.prepareAttachmentBuffer(buffer, 'application/pdf');
+
+      expect(prepared.contentEncoding).toBeUndefined();
+      expect(prepared.optimization).toBe('none');
+      expect(prepared.buffer).toBe(buffer);
+    });
+
+    it('optimizes large images without gzip content encoding', async () => {
+      const buffer = await sharp({
+        create: {
+          width: 2400,
+          height: 2400,
+          channels: 3,
+          background: '#f4f0e8',
+        },
+      })
+        .jpeg({quality: 100})
+        .toBuffer();
+
+      const prepared = await AttachmentHandler.prepareAttachmentBuffer(buffer, 'image/jpeg');
+
+      expect(prepared.contentEncoding).toBeUndefined();
+      expect(prepared.optimization).toBe('image');
+      expect(prepared.buffer.length).toBeLessThan(buffer.length);
+      const metadata = await sharp(prepared.buffer).metadata();
+      expect(Math.max(metadata.width ?? 0, metadata.height ?? 0)).toBeLessThanOrEqual(1920);
+    });
+  });
+
   describe('getFileExtension', () => {
     it('returns lowercase extension without leading dot', () => {
       const file = makeMulFile({originalname: 'photo.PNG'});
@@ -307,7 +351,17 @@ suite('TransactionAttachmentHandler.uploadTransactionAttachments', () => {
     mockGetSignedUrl.mockResolvedValue('https://signed.example.com/new');
     mockRedisSet.mockResolvedValue('OK');
 
-    const file = makeMulFile();
+    const imageBuffer = await sharp({
+      create: {
+        width: 2400,
+        height: 2400,
+        channels: 3,
+        background: '#f4f0e8',
+      },
+    })
+      .png()
+      .toBuffer();
+    const file = makeMulFile({buffer: imageBuffer, size: imageBuffer.length});
     const results = await handler.uploadTransactionAttachments(USER_ID, TX_ID, [file]);
 
     expect(results).toHaveLength(1);
@@ -317,6 +371,30 @@ suite('TransactionAttachmentHandler.uploadTransactionAttachments', () => {
     expect(results[0].contentType).toBe('image/png');
     expect(results[0].signedUrl).toBe('https://signed.example.com/new');
     expect(mockS3Send).toHaveBeenCalledOnce();
+    const command = mockS3Send.mock.calls[0][0];
+    expect(command.input.ContentEncoding).toBeUndefined();
+    expect(command.input.Body.length).toBeLessThan(file.buffer.length);
+  });
+
+  it('uploads the original payload when compression would not reduce file size', async () => {
+    mockDbTransaction.mockImplementationOnce(async (callback: (tx: unknown) => Promise<void>) => {
+      const mockTx = {
+        insert: vi.fn().mockReturnValue({values: vi.fn().mockResolvedValue([])}),
+      };
+      await callback(mockTx);
+    });
+
+    mockS3Send.mockResolvedValue({});
+    mockRedisGet.mockResolvedValue(null);
+    mockGetSignedUrl.mockResolvedValue('https://signed.example.com/raw');
+    mockRedisSet.mockResolvedValue('OK');
+
+    const file = makeMulFile({buffer: Buffer.from([0x1f]), mimetype: 'application/pdf', size: 1});
+    await handler.uploadTransactionAttachments(USER_ID, TX_ID, [file]);
+
+    const command = mockS3Send.mock.calls[0][0];
+    expect(command.input.ContentEncoding).toBeUndefined();
+    expect(command.input.Body).toBe(file.buffer);
   });
 
   it('generates correct S3 storage path', async () => {
@@ -332,7 +410,17 @@ suite('TransactionAttachmentHandler.uploadTransactionAttachments', () => {
     mockGetSignedUrl.mockResolvedValue('https://signed.example.com/path');
     mockRedisSet.mockResolvedValue('OK');
 
-    const file = makeMulFile({originalname: 'receipt.jpg', mimetype: 'image/jpg'});
+    const jpegBuffer = await sharp({
+      create: {
+        width: 10,
+        height: 10,
+        channels: 3,
+        background: '#ffffff',
+      },
+    })
+      .jpeg()
+      .toBuffer();
+    const file = makeMulFile({originalname: 'receipt.jpg', mimetype: 'image/jpg', buffer: jpegBuffer});
     const results = await handler.uploadTransactionAttachments(USER_ID, TX_ID, [file]);
 
     expect(results[0].location).toMatch(new RegExp(`^${USER_ID}/transactions/${TX_ID}/[0-9a-f-]+\\.jpg$`));

--- a/services/backend/src/lib/attachment/attachment.handler.ts
+++ b/services/backend/src/lib/attachment/attachment.handler.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import {gzipSync} from 'node:zlib';
 import type {S3Client} from '@aws-sdk/client-s3';
 import {DeleteObjectsCommand, GetObjectCommand, PutObjectCommand} from '@aws-sdk/client-s3';
 import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
@@ -6,6 +7,7 @@ import type {TypeOfSchema} from '@budgetbuddyde/api';
 import type {IGetAllAttachmentsQuery, TAttachment, TSignedAttachmentUrl} from '@budgetbuddyde/api/attachment';
 import {type AttachmentSchemas, attachments} from '@budgetbuddyde/db/backend';
 import {and, eq, inArray} from 'drizzle-orm';
+import sharp from 'sharp';
 import type winston from 'winston';
 import {db} from '../../db';
 import {AttachmentCache} from '../cache/attachment.cache';
@@ -14,7 +16,13 @@ import {getS3Client} from '../s3';
 
 type AttachmentRecord = TypeOfSchema<typeof AttachmentSchemas.select>;
 
-type SignedUrlOptions = Pick<IGetAllAttachmentsQuery, 'ttl'>;
+type SignedUrlOptions = Partial<Pick<IGetAllAttachmentsQuery, 'ttl'>>;
+
+type PreparedAttachmentBuffer = {
+  buffer: Buffer;
+  contentEncoding?: string;
+  optimization: 'image' | 'gzip' | 'none';
+};
 
 type UploadFileOptions = Pick<
   TAttachment,
@@ -69,6 +77,70 @@ export abstract class AttachmentHandler {
     }
     const ext = AttachmentHandler.getFileExtension(file);
     return AttachmentHandler.EXTENSION_MIME_OVERRIDES[ext] ?? file.mimetype;
+  }
+
+  private static readonly MAX_IMAGE_DIMENSION_PX = 1920;
+
+  private static readonly OPTIMIZABLE_IMAGE_MIME_TYPES = new Set([
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/webp',
+  ]);
+
+  private static isOptimizableImage(contentType: string): boolean {
+    return AttachmentHandler.OPTIMIZABLE_IMAGE_MIME_TYPES.has(contentType);
+  }
+
+  private static async optimizeImageBuffer(fileBuffer: Buffer, contentType: string): Promise<Buffer> {
+    const image = sharp(fileBuffer, {failOn: 'none'}).rotate().resize({
+      width: AttachmentHandler.MAX_IMAGE_DIMENSION_PX,
+      height: AttachmentHandler.MAX_IMAGE_DIMENSION_PX,
+      fit: 'inside',
+      withoutEnlargement: true,
+    });
+
+    switch (contentType) {
+      case 'image/jpeg':
+      case 'image/jpg':
+        return image.jpeg({quality: 82, mozjpeg: true}).toBuffer();
+      case 'image/png':
+        return image.png({compressionLevel: 9, palette: true}).toBuffer();
+      case 'image/webp':
+        return image.webp({quality: 82}).toBuffer();
+      default:
+        return fileBuffer;
+    }
+  }
+
+  /**
+   * Prepare an attachment payload for storage. Images are optimized with
+   * image-aware resizing/re-encoding first because gzip usually does not reduce
+   * already-compressed image formats. Non-images still use gzip when it reduces
+   * the payload size.
+   */
+  static async prepareAttachmentBuffer(fileBuffer: Buffer, contentType: string): Promise<PreparedAttachmentBuffer> {
+    if (AttachmentHandler.isOptimizableImage(contentType)) {
+      try {
+        const optimizedImageBuffer = await AttachmentHandler.optimizeImageBuffer(fileBuffer, contentType);
+
+        if (optimizedImageBuffer.length < fileBuffer.length) {
+          return {buffer: optimizedImageBuffer, optimization: 'image'};
+        }
+      } catch {
+        // Keep the original upload if an image is malformed or libvips cannot decode it.
+      }
+
+      return {buffer: fileBuffer, optimization: 'none'};
+    }
+
+    const compressedBuffer = gzipSync(fileBuffer);
+
+    if (compressedBuffer.length >= fileBuffer.length) {
+      return {buffer: fileBuffer, optimization: 'none'};
+    }
+
+    return {buffer: compressedBuffer, contentEncoding: 'gzip', optimization: 'gzip'};
   }
 
   /**
@@ -241,12 +313,18 @@ export abstract class AttachmentHandler {
 
     this.logger.debug('Inserted attachment metadata into database', {attachmentId: options.id});
 
+    const preparedBuffer = await AttachmentHandler.prepareAttachmentBuffer(
+      options.fileBuffer,
+      options.contentType as string,
+    );
+
     // Upload to S3
     const command = new PutObjectCommand({
       Bucket: this.bucketName,
       Key: options.location,
-      Body: options.fileBuffer,
+      Body: preparedBuffer.buffer,
       ContentType: options.contentType as string,
+      ContentEncoding: preparedBuffer.contentEncoding,
     });
 
     this.logger.debug('Uploading file %s to S3 at %s', options.id, options.location);

--- a/services/backend/src/lib/attachment/transaction-attachment.handler.ts
+++ b/services/backend/src/lib/attachment/transaction-attachment.handler.ts
@@ -79,14 +79,16 @@ export class TransactionAttachmentHandler extends AttachmentHandler {
 
     // Upload all files to S3 in parallel
     await Promise.all(
-      prepared.map(({attachmentId, mimeType, location, file}) => {
+      prepared.map(async ({attachmentId, mimeType, location, file}) => {
+        const preparedBuffer = await AttachmentHandler.prepareAttachmentBuffer(file.buffer, mimeType);
         this.logger.debug('Uploading attachment %s to S3 at %s', attachmentId, location, {attachmentId, location});
         return this.s3Client.send(
           new PutObjectCommand({
             Bucket: this.bucketName,
             Key: location,
-            Body: file.buffer,
+            Body: preparedBuffer.buffer,
             ContentType: mimeType,
+            ContentEncoding: preparedBuffer.contentEncoding,
           }),
         );
       }),


### PR DESCRIPTION
### Motivation
- Reduce storage and bandwidth by optimizing large image uploads and compressing non-image payloads when beneficial.
- Avoid ineffective gzip on already-compressed image formats by applying image-aware resizing/re-encoding first.
- Ensure robust behavior when image decoding fails and expose the optimization decision in uploads (via `ContentEncoding`).

### Description
- Added `sharp` as a dependency and imported `gzipSync` to perform image optimization and gzip compression respectively by defaulting to `sharp`-based resizing/re-encoding for images and `gzip` for non-image payloads when it reduces size.
- Implemented `AttachmentHandler.prepareAttachmentBuffer` plus helper methods and constants to detect optimizable image types, resize to a `MAX_IMAGE_DIMENSION_PX` of `1920`, re-encode per format, or fallback to gzip for other file types, and return `{buffer, contentEncoding?, optimization}`.
- Updated `uploadFile` and `TransactionAttachmentHandler.uploadTransactionAttachments` to call `prepareAttachmentBuffer` and use the prepared buffer and `ContentEncoding` when sending `PutObjectCommand` to S3.
- Extended `attachment.handler.test.ts` with unit tests for `prepareAttachmentBuffer` and updated transaction upload tests to assert that images are optimized and that small/non-compressible payloads are uploaded unchanged.

### Testing
- Ran the unit test suite with `vitest`, including `services/backend/src/__tests__/attachment.handler.test.ts`, and all tests passed.
- Tests validate gzip compression for reducible non-image buffers, no-op behavior when gzip would not shrink payloads, image optimization reducing size and bounding dimensions, and correct S3 `PutObjectCommand` fields (`Body` and `ContentEncoding`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57615c1848832294413b27e9f24d8e)